### PR TITLE
Fix widgets not unsubscribing if type doesn't have a widget implementation

### DIFF
--- a/lib/widgets/network_tree/networktables_tree_row.dart
+++ b/lib/widgets/network_tree/networktables_tree_row.dart
@@ -241,6 +241,10 @@ class NetworkTableTreeRow {
     NTWidget? widget = NTWidgetBuilder.buildNTWidgetFromModel(primary);
 
     if (widget == null) {
+      primary.unSubscribe();
+      primary.disposeWidget(deleting: true);
+      primary.forceDispose();
+
       return null;
     }
 


### PR DESCRIPTION
If you drag a table containing a widget that doesn't have a widget implementation, it will never unsubscribe

This has the widget model be unsubscribed and disposed before returning null in the tree row's `toWidgetContainerModel()` method