### PR TITLE
Fix field objects not rendering if connection is already established during widget creation

### DIFF
--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -203,7 +203,6 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
     Future.delayed(const Duration(seconds: 1), () {
       apiListener.initializeSubscriptions();
       apiListener.initializeListeners();
-      ntConnection.nt4Client.recallAnnounceListeners();
     });
 
     Future(() => _checkForUpdates(notifyIfLatest: false, notifyIfError: false));

--- a/lib/services/nt4_client.dart
+++ b/lib/services/nt4_client.dart
@@ -312,18 +312,14 @@ class NT4Client {
 
   void addTopicAnnounceListener(Function(NT4Topic topic) onAnnounce) {
     _topicAnnounceListeners.add(onAnnounce);
+
+    for (NT4Topic topic in announcedTopics.values) {
+      onAnnounce(topic);
+    }
   }
 
   void removeTopicAnnounceListener(Function(NT4Topic topic) onAnnounce) {
     _topicAnnounceListeners.remove(onAnnounce);
-  }
-
-  void recallAnnounceListeners() {
-    for (NT4Topic topic in announcedTopics.values) {
-      for (var callback in _topicAnnounceListeners) {
-        callback.call(topic);
-      }
-    }
   }
 
   NT4Subscription subscribe(String topic, [double period = 0.1]) {


### PR DESCRIPTION
When adding a topic announce listener, the listener method is called with all previously announced topics.