### PR TITLE
Allow robot created notifications

### DIFF
--- a/elasticlib/Elastic.java
+++ b/elasticlib/Elastic.java
@@ -1,5 +1,6 @@
 package frc.robot;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -23,8 +24,11 @@ public final class Elastic {
     }
 
     public static class ElasticNotification {
+        @JsonProperty("level")
         private NotificationLevel level;
+        @JsonProperty("title")
         private String title;
+        @JsonProperty("description")
         private String description;
 
         public ElasticNotification(NotificationLevel level, String title, String description) {

--- a/elasticlib/Elastic.java
+++ b/elasticlib/Elastic.java
@@ -1,22 +1,53 @@
 package frc.robot;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.PubSubOption;
 import edu.wpi.first.networktables.StringArrayPublisher;
 import edu.wpi.first.networktables.StringArrayTopic;
+import edu.wpi.first.networktables.StringPublisher;
+import edu.wpi.first.networktables.StringTopic;
 
 public final class Elastic {
-    private static final StringArrayTopic topic = NetworkTableInstance.getDefault()
-            .getStringArrayTopic("elastic/robotalerts");
-    private static final StringArrayPublisher publisher = topic.publish(PubSubOption.sendAll(true));
+    private static final StringTopic topic = NetworkTableInstance.getDefault().getStringTopic("elastic/robotalerts");
+    private static final StringPublisher publisher = topic.publish(PubSubOption.sendAll(true));
+    private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    public static void sendAlert(AlertLevel level, String title, String description) {
-        publisher.set(new String[] { level.toString(), title, description });
+    public static void sendAlert(RobotAlert alert) {
+        try {
+            publisher.set(objectMapper.writeValueAsString(alert));
+        } catch (JsonProcessingException e) {
+            e.printStackTrace();
+        }
+    }
+
+    static class RobotAlert {
+        private final AlertLevel level;
+        private final String title;
+        private final String description;
+
+        public RobotAlert(AlertLevel level, String title, String description) {
+            this.level = level;
+            this.title = title;
+            this.description = description;
+        }
+
+        public AlertLevel getLevel() {
+            return level;
+        }
+
+        public String getTitle() {
+            return title;
+        }
+
+        public String getDescription() {
+            return description;
+        }
     }
 
     public enum AlertLevel {
-        INFO,
-        WARNING,
-        ERROR
+        INFO, WARNING, ERROR
     }
 }

--- a/elasticlib/Elastic.java
+++ b/elasticlib/Elastic.java
@@ -33,12 +33,24 @@ public final class Elastic {
             this.description = description;
         }
 
+        public void setLevel(NotificationLevel level) {
+            this.level = level;
+        }
+
         public NotificationLevel getLevel() {
             return level;
         }
 
+        public void setTitle(String title) {
+            this.title = title;
+        }
+
         public String getTitle() {
             return title;
+        }
+
+        public void setDescription(String description) {
+            this.description = description;
         }
 
         public String getDescription() {
@@ -51,5 +63,4 @@ public final class Elastic {
             ERROR
         }
     }
-
 }

--- a/elasticlib/Elastic.java
+++ b/elasticlib/Elastic.java
@@ -1,0 +1,24 @@
+package frc.robot;
+
+import edu.wpi.first.networktables.NetworkTableInstance;
+import edu.wpi.first.networktables.PubSubOption;
+import edu.wpi.first.networktables.PubSubOptions;
+import edu.wpi.first.networktables.StringArrayEntry;
+import edu.wpi.first.networktables.StringArrayPublisher;
+import edu.wpi.first.networktables.StringArrayTopic;
+
+public final class Elastic {
+    private static final StringArrayTopic topic = NetworkTableInstance.getDefault().getStringArrayTopic("notifications");
+    private static final StringArrayPublisher publisher = topic.publish(PubSubOption.sendAll(true));
+
+    public static void sendAlert(AlertLevel level, String title, String description) {
+
+        publisher.set(new String[] {level.toString(), title, description});
+        System.out.println("sent alert");
+    }
+    public enum AlertLevel {
+        INFO,
+        WARNING,
+        ERROR
+    }
+}

--- a/elasticlib/Elastic.java
+++ b/elasticlib/Elastic.java
@@ -5,17 +5,16 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.PubSubOption;
-import edu.wpi.first.networktables.StringArrayPublisher;
-import edu.wpi.first.networktables.StringArrayTopic;
 import edu.wpi.first.networktables.StringPublisher;
 import edu.wpi.first.networktables.StringTopic;
 
 public final class Elastic {
-    private static final StringTopic topic = NetworkTableInstance.getDefault().getStringTopic("elastic/robotalerts");
+    private static final StringTopic topic = NetworkTableInstance.getDefault()
+            .getStringTopic("elastic/robotnotifications");
     private static final StringPublisher publisher = topic.publish(PubSubOption.sendAll(true));
     private static final ObjectMapper objectMapper = new ObjectMapper();
 
-    public static void sendAlert(RobotAlert alert) {
+    public static void sendAlert(ElasticNotification alert) {
         try {
             publisher.set(objectMapper.writeValueAsString(alert));
         } catch (JsonProcessingException e) {
@@ -23,18 +22,18 @@ public final class Elastic {
         }
     }
 
-    static class RobotAlert {
-        private final AlertLevel level;
-        private final String title;
-        private final String description;
+    public static class ElasticNotification {
+        private NotificationLevel level;
+        private String title;
+        private String description;
 
-        public RobotAlert(AlertLevel level, String title, String description) {
+        public ElasticNotification(NotificationLevel level, String title, String description) {
             this.level = level;
             this.title = title;
             this.description = description;
         }
 
-        public AlertLevel getLevel() {
+        public NotificationLevel getLevel() {
             return level;
         }
 
@@ -45,9 +44,12 @@ public final class Elastic {
         public String getDescription() {
             return description;
         }
+
+        public enum NotificationLevel {
+            INFO,
+            WARNING,
+            ERROR
+        }
     }
 
-    public enum AlertLevel {
-        INFO, WARNING, ERROR
-    }
 }

--- a/elasticlib/Elastic.java
+++ b/elasticlib/Elastic.java
@@ -12,9 +12,7 @@ public final class Elastic {
     private static final StringArrayPublisher publisher = topic.publish(PubSubOption.sendAll(true));
 
     public static void sendAlert(AlertLevel level, String title, String description) {
-
         publisher.set(new String[] {level.toString(), title, description});
-        System.out.println("sent alert");
     }
     public enum AlertLevel {
         INFO,

--- a/elasticlib/Elastic.java
+++ b/elasticlib/Elastic.java
@@ -2,18 +2,18 @@ package frc.robot;
 
 import edu.wpi.first.networktables.NetworkTableInstance;
 import edu.wpi.first.networktables.PubSubOption;
-import edu.wpi.first.networktables.PubSubOptions;
-import edu.wpi.first.networktables.StringArrayEntry;
 import edu.wpi.first.networktables.StringArrayPublisher;
 import edu.wpi.first.networktables.StringArrayTopic;
 
 public final class Elastic {
-    private static final StringArrayTopic topic = NetworkTableInstance.getDefault().getStringArrayTopic("notifications");
+    private static final StringArrayTopic topic = NetworkTableInstance.getDefault()
+            .getStringArrayTopic("elastic/robotalerts");
     private static final StringArrayPublisher publisher = topic.publish(PubSubOption.sendAll(true));
 
     public static void sendAlert(AlertLevel level, String title, String description) {
-        publisher.set(new String[] {level.toString(), title, description});
+        publisher.set(new String[] { level.toString(), title, description });
     }
+
     public enum AlertLevel {
         INFO,
         WARNING,

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -1,6 +1,8 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
+import 'package:elegant_notification/resources/stacked_options.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter/services.dart';
@@ -9,6 +11,7 @@ import 'package:collection/collection.dart';
 import 'package:dot_cast/dot_cast.dart';
 import 'package:elegant_notification/elegant_notification.dart';
 import 'package:file_selector/file_selector.dart';
+import 'package:logger/logger.dart';
 import 'package:popover/popover.dart';
 import 'package:screen_retriever/screen_retriever.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -206,6 +209,61 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
     });
 
     Future(() => _checkForUpdates(notifyIfLatest: false, notifyIfError: false));
+
+    var notifications = ntConnection.subscribe("notifications");
+
+    //dont display a notification when we first connect
+    bool notificationFirstRun = true;
+    notifications.listen((p0, p1) {
+      List<String> data = p0.toString().replaceAll("[", "").replaceAll("]", "").split(",");
+      if(notificationFirstRun) {
+        notificationFirstRun = false;
+        return;
+      }
+      Icon icon;
+      if(data[0] == "INFO") {
+        icon = const Icon(Icons.info);
+      }
+      else if(data[0] == "WARNING") {
+        icon = const Icon(Icons.warning_amber, color: Colors.orange,);
+      }
+      else if(data[0] == "ERROR") {
+        icon = const Icon(Icons.error, color: Colors.red,);
+      }
+      else {
+        icon = const Icon(Icons.question_mark);
+      }
+
+      String title = data[1];
+      String description = data[2];
+      setState(() {
+        ColorScheme colorScheme = Theme.of(context).colorScheme;
+        TextTheme textTheme = Theme.of(context).textTheme;
+        ElegantNotification notification = ElegantNotification(
+          autoDismiss: true,
+          showProgressIndicator: true,
+          background: colorScheme.surface,
+          width: 350,
+          position: Alignment.bottomRight,
+          title: Text(
+            title,
+            style: textTheme.bodyMedium!.copyWith(
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          icon: icon,
+          description: Text(description),
+          stackedOptions: StackedOptions(
+            key: 'notification',
+            type: StackedType.above,
+            itemOffset: const Offset(0, 20),
+          ),
+        );
+        if (mounted) {
+          notification.show(context);
+        }
+      });
+    });
   }
 
   @override
@@ -271,7 +329,6 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
         background: colorScheme.surface,
         progressIndicatorBackground: colorScheme.surface,
         progressIndicatorColor: const Color(0xff01CB67),
-        enableShadow: false,
         width: 150,
         position: Alignment.bottomRight,
         toastDuration: const Duration(seconds: 3, milliseconds: 500),
@@ -291,7 +348,6 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
         background: colorScheme.surface,
         progressIndicatorBackground: colorScheme.surface,
         progressIndicatorColor: const Color(0xffFE355C),
-        enableShadow: false,
         width: 150,
         position: Alignment.bottomRight,
         toastDuration: const Duration(seconds: 3, milliseconds: 500),
@@ -337,9 +393,7 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
         background: colorScheme.surface,
         progressIndicatorBackground: colorScheme.surface,
         progressIndicatorColor: const Color(0xffFE355C),
-        enableShadow: false,
         width: 350,
-        height: 100,
         position: Alignment.bottomRight,
         toastDuration: const Duration(seconds: 3, milliseconds: 500),
         icon: const Icon(Icons.error, color: Color(0xffFE355C)),
@@ -365,9 +419,7 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
         autoDismiss: false,
         showProgressIndicator: false,
         background: colorScheme.surface,
-        enableShadow: false,
-        width: 150,
-        height: 100,
+        width: 350,
         position: Alignment.bottomRight,
         title: Text(
           'Version ${updateResponse.latestVersion!} Available',
@@ -384,7 +436,7 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
             fontWeight: FontWeight.bold,
           ),
         ),
-        onActionPressed: () async {
+        onNotificationPressed: () async {
           Uri url = Uri.parse(Settings.releasesLink);
 
           if (await canLaunchUrl(url)) {
@@ -401,9 +453,8 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
         background: colorScheme.surface,
         progressIndicatorBackground: colorScheme.surface,
         progressIndicatorColor: const Color(0xff01CB67),
-        enableShadow: false,
-        width: 150,
-        height: 100,
+        width: 350,
+        
         position: Alignment.bottomRight,
         toastDuration: const Duration(seconds: 3, milliseconds: 500),
         icon: const Icon(Icons.check_circle, color: Color(0xff01CB67)),
@@ -613,7 +664,6 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
         background: colorScheme.surface,
         progressIndicatorBackground: colorScheme.surface,
         progressIndicatorColor: const Color(0xffFE355C),
-        enableShadow: false,
         width: 350,
         height: 100 + (lines - 1) * 10,
         position: Alignment.bottomRight,
@@ -640,7 +690,6 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
         background: colorScheme.surface,
         progressIndicatorBackground: colorScheme.surface,
         progressIndicatorColor: Colors.yellow,
-        enableShadow: false,
         width: 350,
         height: 100 + (lines - 1) * 10,
         position: Alignment.bottomRight,

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -1,8 +1,21 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
+
 import 'package:collection/collection.dart';
 import 'package:dot_cast/dot_cast.dart';
+import 'package:elegant_notification/elegant_notification.dart';
+import 'package:elegant_notification/resources/stacked_options.dart';
+import 'package:file_selector/file_selector.dart';
+import 'package:popover/popover.dart';
+import 'package:screen_retriever/screen_retriever.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:window_manager/window_manager.dart';
+
 import 'package:elastic_dashboard/services/hotkey_manager.dart';
 import 'package:elastic_dashboard/services/ip_address_util.dart';
 import 'package:elastic_dashboard/services/log.dart';
@@ -20,18 +33,6 @@ import 'package:elastic_dashboard/widgets/editable_tab_bar.dart';
 import 'package:elastic_dashboard/widgets/network_tree/networktables_tree.dart';
 import 'package:elastic_dashboard/widgets/settings_dialog.dart';
 import 'package:elastic_dashboard/widgets/tab_grid.dart';
-import 'package:elegant_notification/elegant_notification.dart';
-import 'package:elegant_notification/resources/stacked_options.dart';
-import 'package:file_selector/file_selector.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
-import 'package:flutter/services.dart';
-import 'package:popover/popover.dart';
-import 'package:screen_retriever/screen_retriever.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:url_launcher/url_launcher.dart';
-import 'package:window_manager/window_manager.dart';
-
 import '../widgets/draggable_containers/models/layout_container_model.dart';
 
 class DashboardPage extends StatefulWidget {

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -256,7 +256,7 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
           stackedOptions: StackedOptions(
             key: 'notification',
             type: StackedType.above,
-            itemOffset: const Offset(0, 20),
+            itemOffset: const Offset(0, 5),
           ),
         );
         if (mounted) {

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -21,6 +21,7 @@ import 'package:elastic_dashboard/widgets/network_tree/networktables_tree.dart';
 import 'package:elastic_dashboard/widgets/settings_dialog.dart';
 import 'package:elastic_dashboard/widgets/tab_grid.dart';
 import 'package:elegant_notification/elegant_notification.dart';
+import 'package:elegant_notification/resources/stacked_options.dart';
 import 'package:file_selector/file_selector.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
@@ -52,7 +53,7 @@ class DashboardPage extends StatefulWidget {
 class _DashboardPageState extends State<DashboardPage> with WindowListener {
   late final SharedPreferences _preferences;
   late final UpdateChecker _updateChecker;
-  late final RobotNotificationsListener _robotAlerts;
+  late final RobotNotificationsListener _robotNotificationListener;
 
   final List<TabGrid> _grids = [];
 
@@ -208,8 +209,36 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
 
     Future(() => _checkForUpdates(notifyIfLatest: false, notifyIfError: false));
 
-    _robotAlerts = RobotNotificationsListener();
-    _robotAlerts.listen(ntConnection, context);
+    _robotNotificationListener = RobotNotificationsListener(
+        connection: ntConnection,
+        onNotification: (title, description, icon) {
+          setState(() {
+            ColorScheme colorScheme = Theme.of(context).colorScheme;
+            TextTheme textTheme = Theme.of(context).textTheme;
+            var widget = ElegantNotification(
+              autoDismiss: true,
+              showProgressIndicator: true,
+              background: colorScheme.surface,
+              width: 350,
+              position: Alignment.bottomRight,
+              title: Text(
+                title,
+                style: textTheme.bodyMedium!.copyWith(
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+              icon: icon,
+              description: Text(description),
+              stackedOptions: StackedOptions(
+                key: 'robotnotification',
+                type: StackedType.above,
+                itemOffset: const Offset(0, 5),
+              ),
+            );
+            if (mounted) widget.show(context);
+          });
+        });
+    _robotNotificationListener.listen();
   }
 
   @override

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -1,25 +1,13 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:elastic_dashboard/services/robot_alerts.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter/scheduler.dart';
-import 'package:flutter/services.dart';
-
 import 'package:collection/collection.dart';
 import 'package:dot_cast/dot_cast.dart';
-import 'package:elegant_notification/elegant_notification.dart';
-import 'package:file_selector/file_selector.dart';
-import 'package:popover/popover.dart';
-import 'package:screen_retriever/screen_retriever.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:url_launcher/url_launcher.dart';
-import 'package:window_manager/window_manager.dart';
-
 import 'package:elastic_dashboard/services/hotkey_manager.dart';
 import 'package:elastic_dashboard/services/ip_address_util.dart';
 import 'package:elastic_dashboard/services/log.dart';
 import 'package:elastic_dashboard/services/nt_connection.dart';
+import 'package:elastic_dashboard/services/robot_notifications_listener.dart';
 import 'package:elastic_dashboard/services/settings.dart';
 import 'package:elastic_dashboard/services/shuffleboard_nt_listener.dart';
 import 'package:elastic_dashboard/services/update_checker.dart';
@@ -32,6 +20,17 @@ import 'package:elastic_dashboard/widgets/editable_tab_bar.dart';
 import 'package:elastic_dashboard/widgets/network_tree/networktables_tree.dart';
 import 'package:elastic_dashboard/widgets/settings_dialog.dart';
 import 'package:elastic_dashboard/widgets/tab_grid.dart';
+import 'package:elegant_notification/elegant_notification.dart';
+import 'package:file_selector/file_selector.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/services.dart';
+import 'package:popover/popover.dart';
+import 'package:screen_retriever/screen_retriever.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:window_manager/window_manager.dart';
+
 import '../widgets/draggable_containers/models/layout_container_model.dart';
 
 class DashboardPage extends StatefulWidget {
@@ -53,7 +52,7 @@ class DashboardPage extends StatefulWidget {
 class _DashboardPageState extends State<DashboardPage> with WindowListener {
   late final SharedPreferences _preferences;
   late final UpdateChecker _updateChecker;
-  late final RobotAlerts _robotAlerts;
+  late final RobotNotificationsListener _robotAlerts;
 
   final List<TabGrid> _grids = [];
 
@@ -209,7 +208,7 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
 
     Future(() => _checkForUpdates(notifyIfLatest: false, notifyIfError: false));
 
-    _robotAlerts = RobotAlerts();
+    _robotAlerts = RobotNotificationsListener();
     _robotAlerts.listen(ntConnection, context);
   }
 

--- a/lib/services/nt4_client.dart
+++ b/lib/services/nt4_client.dart
@@ -326,7 +326,7 @@ class NT4Client {
     NT4Subscription newSub = NT4Subscription(
       topic: topic,
       uid: getNewSubUID(),
-      options: NT4SubscriptionOptions(periodicRateSeconds: period),
+      options: NT4SubscriptionOptions(periodicRateSeconds: period, all: true),
     );
 
     if (_subscribedTopics.contains(newSub)) {

--- a/lib/services/nt4_client.dart
+++ b/lib/services/nt4_client.dart
@@ -5,15 +5,13 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
-import 'package:flutter/foundation.dart';
-
 import 'package:collection/collection.dart';
 import 'package:dot_cast/dot_cast.dart';
+import 'package:elastic_dashboard/services/log.dart';
+import 'package:flutter/foundation.dart';
 import 'package:messagepack/messagepack.dart';
 import 'package:msgpack_dart/msgpack_dart.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
-
-import 'package:elastic_dashboard/services/log.dart';
 
 class NT4TypeStr {
   static final Map<String, int> typeMap = {
@@ -322,11 +320,12 @@ class NT4Client {
     _topicAnnounceListeners.remove(onAnnounce);
   }
 
-  NT4Subscription subscribe(String topic, [double period = 0.1]) {
+  NT4Subscription subscribe(String topic,
+      [double period = 0.1, bool all = false]) {
     NT4Subscription newSub = NT4Subscription(
       topic: topic,
       uid: getNewSubUID(),
-      options: NT4SubscriptionOptions(periodicRateSeconds: period, all: true),
+      options: NT4SubscriptionOptions(periodicRateSeconds: period, all: all),
     );
 
     if (_subscribedTopics.contains(newSub)) {
@@ -349,6 +348,10 @@ class NT4Client {
     }
 
     return newSub;
+  }
+
+  NT4Subscription subscribeAll(String topic, [double period = 0.1]) {
+    return subscribe(topic, period, true);
   }
 
   NT4Subscription subscribeAllSamples(String topic, [double period = 0.1]) {

--- a/lib/services/nt4_client.dart
+++ b/lib/services/nt4_client.dart
@@ -5,13 +5,15 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
 
+import 'package:flutter/foundation.dart';
+
 import 'package:collection/collection.dart';
 import 'package:dot_cast/dot_cast.dart';
-import 'package:elastic_dashboard/services/log.dart';
-import 'package:flutter/foundation.dart';
 import 'package:messagepack/messagepack.dart';
 import 'package:msgpack_dart/msgpack_dart.dart';
 import 'package:web_socket_channel/web_socket_channel.dart';
+
+import 'package:elastic_dashboard/services/log.dart';
 
 class NT4TypeStr {
   static final Map<String, int> typeMap = {

--- a/lib/services/nt_connection.dart
+++ b/lib/services/nt_connection.dart
@@ -1,6 +1,7 @@
+import 'package:flutter/foundation.dart';
+
 import 'package:elastic_dashboard/services/ds_interop.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
-import 'package:flutter/foundation.dart';
 
 NTConnection get ntConnection => NTConnection.instance;
 

--- a/lib/services/nt_connection.dart
+++ b/lib/services/nt_connection.dart
@@ -1,7 +1,6 @@
-import 'package:flutter/foundation.dart';
-
 import 'package:elastic_dashboard/services/ds_interop.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
+import 'package:flutter/foundation.dart';
 
 NTConnection get ntConnection => NTConnection.instance;
 
@@ -130,6 +129,10 @@ class NTConnection {
 
   NT4Subscription subscribe(String topic, [double period = 0.1]) {
     return _ntClient.subscribe(topic, period);
+  }
+
+  NT4Subscription subscribeAll(String topic, [double period = 0.1]) {
+    return _ntClient.subscribeAll(topic, period);
   }
 
   void unSubscribe(NT4Subscription subscription) {

--- a/lib/services/robot_alerts.dart
+++ b/lib/services/robot_alerts.dart
@@ -1,0 +1,72 @@
+import 'package:elastic_dashboard/services/nt_connection.dart';
+import 'package:elegant_notification/elegant_notification.dart';
+import 'package:elegant_notification/resources/stacked_options.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+
+class RobotAlerts {
+  bool _alertFirstRun = true;
+
+  void listen(NTConnection nt, BuildContext context) {
+    var notifications = ntConnection.subscribe("elastic/robotalerts");
+    notifications.listen((alertData, alertTimestamp) {
+      _onAlert(alertData!, alertTimestamp, context);
+    });
+  }
+
+  void _onAlert(Object alertData, int timestamp, BuildContext context) {
+    //prevent showing a notification when we connect to NT
+    if (_alertFirstRun) {
+      _alertFirstRun = false;
+      return;
+    }
+    List<String> data =
+        alertData.toString().replaceAll("[", "").replaceAll("]", "").split(",");
+    Icon icon;
+    if (data[0] == "INFO") {
+      icon = const Icon(Icons.info);
+    } else if (data[0] == "WARNING") {
+      icon = const Icon(
+        Icons.warning_amber,
+        color: Colors.orange,
+      );
+    } else if (data[0] == "ERROR") {
+      icon = const Icon(
+        Icons.error,
+        color: Colors.red,
+      );
+    } else {
+      icon = const Icon(Icons.question_mark);
+    }
+
+    String title = data[1];
+    String description = data[2];
+    _buildNotification(title, description, icon, context).show(context);
+  }
+
+  ElegantNotification _buildNotification(
+      String title, String description, Icon icon, BuildContext context) {
+    ColorScheme colorScheme = Theme.of(context).colorScheme;
+    TextTheme textTheme = Theme.of(context).textTheme;
+    return ElegantNotification(
+      autoDismiss: true,
+      showProgressIndicator: true,
+      background: colorScheme.surface,
+      width: 350,
+      position: Alignment.bottomRight,
+      title: Text(
+        title,
+        style: textTheme.bodyMedium!.copyWith(
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      icon: icon,
+      description: Text(description),
+      stackedOptions: StackedOptions(
+        key: 'robotalert',
+        type: StackedType.above,
+        itemOffset: const Offset(0, 5),
+      ),
+    );
+  }
+}

--- a/lib/services/robot_alerts.dart
+++ b/lib/services/robot_alerts.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'package:elegant_notification/elegant_notification.dart';
 import 'package:elegant_notification/resources/stacked_options.dart';
@@ -20,17 +22,19 @@ class RobotAlerts {
       _alertFirstRun = false;
       return;
     }
-    List<String> data =
-        alertData.toString().replaceAll("[", "").replaceAll("]", "").split(",");
+
+
+    Map<String, dynamic> data = jsonDecode(alertData.toString());
     Icon icon;
-    if (data[0] == "INFO") {
+
+    if (data["level"] == "INFO") {
       icon = const Icon(Icons.info);
-    } else if (data[0] == "WARNING") {
+    } else if (data["level"] == "WARNING") {
       icon = const Icon(
         Icons.warning_amber,
         color: Colors.orange,
       );
-    } else if (data[0] == "ERROR") {
+    } else if (data["level"] == "ERROR") {
       icon = const Icon(
         Icons.error,
         color: Colors.red,
@@ -39,9 +43,7 @@ class RobotAlerts {
       icon = const Icon(Icons.question_mark);
     }
 
-    String title = data[1];
-    String description = data[2];
-    _buildNotification(title, description, icon, context).show(context);
+    _buildNotification(data["title"], data["description"], icon, context).show(context);
   }
 
   ElegantNotification _buildNotification(

--- a/lib/services/robot_alerts.dart
+++ b/lib/services/robot_alerts.dart
@@ -3,7 +3,6 @@ import 'dart:convert';
 import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'package:elegant_notification/elegant_notification.dart';
 import 'package:elegant_notification/resources/stacked_options.dart';
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 
 class RobotAlerts {
@@ -22,7 +21,6 @@ class RobotAlerts {
       _alertFirstRun = false;
       return;
     }
-
 
     Map<String, dynamic> data = jsonDecode(alertData.toString());
     Icon icon;
@@ -43,7 +41,8 @@ class RobotAlerts {
       icon = const Icon(Icons.question_mark);
     }
 
-    _buildNotification(data["title"], data["description"], icon, context).show(context);
+    _buildNotification(data["title"], data["description"], icon, context)
+        .show(context);
   }
 
   ElegantNotification _buildNotification(

--- a/lib/services/robot_notifications_listener.dart
+++ b/lib/services/robot_notifications_listener.dart
@@ -1,5 +1,6 @@
 import 'dart:convert';
 
+import 'package:dot_cast/dot_cast.dart';
 import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'package:flutter/material.dart';
 
@@ -44,6 +45,13 @@ class RobotNotificationsListener {
     } else {
       icon = const Icon(Icons.question_mark);
     }
-    onNotification(data["title"], data["description"], icon);
+    String? title = tryCast(data['title']);
+    String? description = tryCast(data['description']);
+
+    if (title == null || description == null) {
+      return;
+    }
+    
+    onNotification(title, description, icon);
   }
 }

--- a/lib/services/robot_notifications_listener.dart
+++ b/lib/services/robot_notifications_listener.dart
@@ -12,7 +12,8 @@ class RobotNotificationsListener {
       {required this.connection, required this.onNotification});
 
   void listen() {
-    var notifications = ntConnection.subscribe("elastic/robotnotifications");
+    var notifications =
+        ntConnection.subscribeAll("elastic/robotnotifications", 0.2);
     notifications.listen((alertData, alertTimestamp) {
       _onAlert(alertData!, alertTimestamp);
     });

--- a/lib/services/robot_notifications_listener.dart
+++ b/lib/services/robot_notifications_listener.dart
@@ -1,21 +1,24 @@
 import 'dart:convert';
 
 import 'package:elastic_dashboard/services/nt_connection.dart';
-import 'package:elegant_notification/elegant_notification.dart';
-import 'package:elegant_notification/resources/stacked_options.dart';
 import 'package:flutter/material.dart';
 
 class RobotNotificationsListener {
   bool _alertFirstRun = true;
+  final NTConnection connection;
+  final Function(String title, String description, Icon icon) onNotification;
 
-  void listen(NTConnection nt, BuildContext context) {
+  RobotNotificationsListener(
+      {required this.connection, required this.onNotification});
+
+  void listen() {
     var notifications = ntConnection.subscribe("elastic/robotnotifications");
     notifications.listen((alertData, alertTimestamp) {
-      _onAlert(alertData!, alertTimestamp, context);
+      _onAlert(alertData!, alertTimestamp);
     });
   }
 
-  void _onAlert(Object alertData, int timestamp, BuildContext context) {
+  void _onAlert(Object alertData, int timestamp) {
     //prevent showing a notification when we connect to NT
     if (_alertFirstRun) {
       _alertFirstRun = false;
@@ -40,34 +43,6 @@ class RobotNotificationsListener {
     } else {
       icon = const Icon(Icons.question_mark);
     }
-
-    _buildNotification(data["title"], data["description"], icon, context)
-        .show(context);
-  }
-
-  ElegantNotification _buildNotification(
-      String title, String description, Icon icon, BuildContext context) {
-    ColorScheme colorScheme = Theme.of(context).colorScheme;
-    TextTheme textTheme = Theme.of(context).textTheme;
-    return ElegantNotification(
-      autoDismiss: true,
-      showProgressIndicator: true,
-      background: colorScheme.surface,
-      width: 350,
-      position: Alignment.bottomRight,
-      title: Text(
-        title,
-        style: textTheme.bodyMedium!.copyWith(
-          fontWeight: FontWeight.bold,
-        ),
-      ),
-      icon: icon,
-      description: Text(description),
-      stackedOptions: StackedOptions(
-        key: 'robotnotification',
-        type: StackedType.above,
-        itemOffset: const Offset(0, 5),
-      ),
-    );
+    onNotification(data["title"], data["description"], icon);
   }
 }

--- a/lib/services/robot_notifications_listener.dart
+++ b/lib/services/robot_notifications_listener.dart
@@ -5,11 +5,11 @@ import 'package:elegant_notification/elegant_notification.dart';
 import 'package:elegant_notification/resources/stacked_options.dart';
 import 'package:flutter/material.dart';
 
-class RobotAlerts {
+class RobotNotificationsListener {
   bool _alertFirstRun = true;
 
   void listen(NTConnection nt, BuildContext context) {
-    var notifications = ntConnection.subscribe("elastic/robotalerts");
+    var notifications = ntConnection.subscribe("elastic/robotnotifications");
     notifications.listen((alertData, alertTimestamp) {
       _onAlert(alertData!, alertTimestamp, context);
     });
@@ -64,7 +64,7 @@ class RobotAlerts {
       icon: icon,
       description: Text(description),
       stackedOptions: StackedOptions(
-        key: 'robotalert',
+        key: 'robotnotification',
         type: StackedType.above,
         itemOffset: const Offset(0, 5),
       ),

--- a/lib/services/robot_notifications_listener.dart
+++ b/lib/services/robot_notifications_listener.dart
@@ -1,16 +1,20 @@
 import 'dart:convert';
 
-import 'package:dot_cast/dot_cast.dart';
-import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'package:flutter/material.dart';
+
+import 'package:dot_cast/dot_cast.dart';
+
+import 'package:elastic_dashboard/services/nt_connection.dart';
 
 class RobotNotificationsListener {
   bool _alertFirstRun = true;
   final NTConnection connection;
   final Function(String title, String description, Icon icon) onNotification;
 
-  RobotNotificationsListener(
-      {required this.connection, required this.onNotification});
+  RobotNotificationsListener({
+    required this.connection,
+    required this.onNotification,
+  });
 
   void listen() {
     var notifications =
@@ -51,7 +55,7 @@ class RobotNotificationsListener {
     if (title == null || description == null) {
       return;
     }
-    
+
     onNotification(title, description, icon);
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -253,10 +253,10 @@ packages:
     dependency: "direct main"
     description:
       name: elegant_notification
-      sha256: "94cf7377a939b101183a3093fea409c26c332511ba8d2da445ef8b251d460dc9"
+      sha256: f6ad40163a06ac5c41fe698d39c4e45b5d6c1617d6cd17062e11e1ecd39b3a97
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.0"
+    version: "2.2.0"
   equatable:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   decimal: ^2.3.3
   dot_cast: ^1.2.0
   dropdown_button2: ^2.3.9
-  elegant_notification: ^1.11.0
+  elegant_notification: ^2.2.0
   file_selector: ^1.0.1
   flex_seed_scheme: ^2.0.0
   flutter:

--- a/test/pages/dashboard_page_test.dart
+++ b/test/pages/dashboard_page_test.dart
@@ -1,14 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
-
-import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:titlebar_buttons/titlebar_buttons.dart';
-
 import 'package:elastic_dashboard/pages/dashboard_page.dart';
 import 'package:elastic_dashboard/services/field_images.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
@@ -26,6 +18,13 @@ import 'package:elastic_dashboard/widgets/nt_widgets/multi-topic/combo_box_choos
 import 'package:elastic_dashboard/widgets/nt_widgets/single_topic/boolean_box.dart';
 import 'package:elastic_dashboard/widgets/settings_dialog.dart';
 import 'package:elastic_dashboard/widgets/tab_grid.dart';
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:titlebar_buttons/titlebar_buttons.dart';
+
 import '../test_util.dart';
 import '../test_util.mocks.dart';
 
@@ -371,6 +370,10 @@ void main() {
     when(mockNT4Connection.subscribe(any, any)).thenReturn(mockSubscription);
 
     when(mockNT4Connection.subscribe(any)).thenReturn(mockSubscription);
+
+    when(mockNT4Connection.subscribeAll(any, any)).thenReturn(mockSubscription);
+
+    when(mockNT4Connection.subscribeAll(any)).thenReturn(mockSubscription);
 
     when(mockNT4Connection.subscribeAndRetrieveData<List<Object?>>(
             '/Shuffleboard/.metadata/Test-Tab/Shuffleboard Test Number/Position'))

--- a/test/pages/dashboard_page_test.dart
+++ b/test/pages/dashboard_page_test.dart
@@ -1,6 +1,14 @@
 import 'dart:convert';
 import 'dart:io';
 
+import 'package:flutter/gestures.dart';
+import 'package:flutter/material.dart';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:titlebar_buttons/titlebar_buttons.dart';
+
 import 'package:elastic_dashboard/pages/dashboard_page.dart';
 import 'package:elastic_dashboard/services/field_images.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
@@ -18,13 +26,6 @@ import 'package:elastic_dashboard/widgets/nt_widgets/multi-topic/combo_box_choos
 import 'package:elastic_dashboard/widgets/nt_widgets/single_topic/boolean_box.dart';
 import 'package:elastic_dashboard/widgets/settings_dialog.dart';
 import 'package:elastic_dashboard/widgets/tab_grid.dart';
-import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:titlebar_buttons/titlebar_buttons.dart';
-
 import '../test_util.dart';
 import '../test_util.mocks.dart';
 

--- a/test/services/shuffleboard_nt_listener_test.dart
+++ b/test/services/shuffleboard_nt_listener_test.dart
@@ -1,10 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'package:elastic_dashboard/services/settings.dart';
 import 'package:elastic_dashboard/services/shuffleboard_nt_listener.dart';
-import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
-
 import '../test_util.mocks.dart';
 
 void main() {

--- a/test/services/shuffleboard_nt_listener_test.dart
+++ b/test/services/shuffleboard_nt_listener_test.dart
@@ -1,10 +1,10 @@
-import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/mockito.dart';
-
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'package:elastic_dashboard/services/settings.dart';
 import 'package:elastic_dashboard/services/shuffleboard_nt_listener.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+
 import '../test_util.mocks.dart';
 
 void main() {
@@ -47,6 +47,10 @@ void main() {
     when(mockNT4Connection.subscribe(any, any)).thenReturn(mockSubscription);
 
     when(mockNT4Connection.subscribe(any)).thenReturn(mockSubscription);
+
+    when(mockNT4Connection.subscribeAll(any, any)).thenReturn(mockSubscription);
+
+    when(mockNT4Connection.subscribeAll(any)).thenReturn(mockSubscription);
 
     NTConnection.instance = mockNT4Connection;
 

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -1,11 +1,12 @@
 import 'dart:io';
 
-import 'package:elastic_dashboard/services/nt4_client.dart';
-import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'package:flutter/material.dart';
+
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
+import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'test_util.mocks.dart';
 
 @GenerateNiceMocks([

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -1,12 +1,11 @@
 import 'dart:io';
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
+import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'package:flutter/material.dart';
-
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 
-import 'package:elastic_dashboard/services/nt4_client.dart';
-import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'test_util.mocks.dart';
 
 @GenerateNiceMocks([
@@ -40,6 +39,10 @@ void setupMockOfflineNT4() {
   when(mockNT4Connection.subscribe(any, any)).thenReturn(mockSubscription);
 
   when(mockNT4Connection.subscribe(any)).thenReturn(mockSubscription);
+
+  when(mockNT4Connection.subscribeAll(any, any)).thenReturn(mockSubscription);
+
+  when(mockNT4Connection.subscribeAll(any)).thenReturn(mockSubscription);
 
   when(mockNT4Connection.getTopicFromName(any))
       .thenReturn(NT4Topic(name: '', type: NT4TypeStr.kString, properties: {}));
@@ -86,6 +89,10 @@ void setupMockOnlineNT4() {
   when(mockNT4Connection.subscribe(any, any)).thenReturn(mockSubscription);
 
   when(mockNT4Connection.subscribe(any)).thenReturn(mockSubscription);
+
+  when(mockNT4Connection.subscribeAll(any, any)).thenReturn(mockSubscription);
+
+  when(mockNT4Connection.subscribeAll(any)).thenReturn(mockSubscription);
 
   when(mockNT4Connection.getTopicFromName(any))
       .thenReturn(NT4Topic(name: '', type: NT4TypeStr.kString, properties: {}));


### PR DESCRIPTION

https://github.com/Gold872/elastic-dashboard/assets/68785503/6e22f1bb-cafc-4cf4-82bd-e77da0f40d26


Robot code usage: 
```java
 @Override
  public void autonomousInit() {
    Elastic.sendAlert(AlertLevel.INFO, "Autonomous!", "The robot is now in auto.");
```

There are 3 levels of notifications:

INFO: 
![image](https://github.com/Gold872/elastic-dashboard/assets/68785503/26fe05e0-9076-47f6-abfd-84ba2c8e31e9)

WARNING: 
![image](https://github.com/Gold872/elastic-dashboard/assets/68785503/0e2e9170-ba6c-4b6e-a959-2fe08125a0b7)

ERROR:
![image](https://github.com/Gold872/elastic-dashboard/assets/68785503/c94b1231-c3b9-46f8-88cd-5bdb84e43853)



The idea is that the driver can get a notification when something happens (eg. an arm extends too far and gets disabled). 

Users can copy the Elastic class into their robot project, and use those methods to push notifications to the dashboard.