### PR TITLE
Fix camera stream edge case error when no image is received 

### DIFF
--- a/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
+++ b/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
@@ -280,7 +280,8 @@ class CameraStreamWidget extends NTWidget {
           return Stack(
             fit: StackFit.expand,
             children: [
-              if (model.mjpegStream != null || model.lastDisplayedImage != null)
+              if (model.mjpegStream?.previousImage != null ||
+                  model.lastDisplayedImage != null)
                 Opacity(
                   opacity: 0.35,
                   child: Image(


### PR DESCRIPTION
After disconnecting from network tables, if no image was received from a camera stream, there would be an error due to trying to display an image from an empty cache. This is a fix for it.