### PR TITLE
Use ValueListenableBuilder for NT widget state

### DIFF
--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -1871,7 +1871,7 @@ class _AddWidgetDialogState extends State<_AddWidgetDialog> {
                                 setState(() => _searchQuery = value),
                             initialText: _searchQuery,
                             allowEmptySubmission: true,
-                            label: "Search",
+                            label: 'Search',
                           ),
                         ),
                       ),

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -1437,7 +1437,7 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
                         setState(() {
                           _tabData[_currentTabIndex]
                               .tabGrid
-                              .clearWidgets(context);
+                              .confirmClearWidgets(context);
                         });
                       }
                     : null,

--- a/lib/services/nt4_client.dart
+++ b/lib/services/nt4_client.dart
@@ -244,6 +244,7 @@ class NT4Client {
   final VoidCallback? onConnect;
   final VoidCallback? onDisconnect;
   final List<Function(NT4Topic topic)> _topicAnnounceListeners = [];
+  final List<Function(NT4Topic topic)> _topicUnannounceListeners = [];
 
   final Map<int, NT4Subscription> _subscriptions = {};
   final Set<NT4Subscription> _subscribedTopics = {};
@@ -327,6 +328,14 @@ class NT4Client {
 
   void removeTopicAnnounceListener(Function(NT4Topic topic) onAnnounce) {
     _topicAnnounceListeners.remove(onAnnounce);
+  }
+
+  void addTopicUnannounceListener(Function(NT4Topic topic) onUnannounce) {
+    _topicUnannounceListeners.add(onUnannounce);
+  }
+
+  void removeTopicUnannounceListener(Function(NT4Topic topic) onUnannounce) {
+    _topicUnannounceListeners.add(onUnannounce);
   }
 
   NT4Subscription subscribe({
@@ -794,6 +803,10 @@ class NT4Client {
             return;
           }
           announcedTopics.remove(removedTopic.id);
+
+          for (final listener in _topicUnannounceListeners) {
+            listener.call(removedTopic);
+          }
         } else if (method == 'properties') {
           String topicName = params['name'];
           NT4Topic? topic = getTopicFromName(topicName);

--- a/lib/services/nt4_client.dart
+++ b/lib/services/nt4_client.dart
@@ -53,12 +53,10 @@ class NT4TypeStr {
   static const kStringArr = 'string[]';
 }
 
-class NT4Subscription {
+class NT4Subscription extends ValueNotifier<Object?> {
   final String topic;
   final NT4SubscriptionOptions options;
   final int uid;
-
-  ValueNotifier<Object?> value = ValueNotifier<Object?>(null);
 
   Object? currentValue;
   int timestamp = 0;
@@ -69,7 +67,7 @@ class NT4Subscription {
     required this.topic,
     this.options = const NT4SubscriptionOptions(),
     this.uid = -1,
-  });
+  }) : super(null);
 
   void listen(Function(Object?, int) onChanged) {
     _listeners.add(onChanged);
@@ -127,9 +125,9 @@ class NT4Subscription {
     for (var listener in _listeners) {
       listener(value, timestamp);
     }
-    this.value.value = value;
     currentValue = value;
     this.timestamp = timestamp;
+    super.value = value;
   }
 
   Map<String, dynamic> _toSubscribeJson() {

--- a/lib/services/nt4_client.dart
+++ b/lib/services/nt4_client.dart
@@ -58,6 +58,8 @@ class NT4Subscription {
   final NT4SubscriptionOptions options;
   final int uid;
 
+  ValueNotifier<Object?> value = ValueNotifier<Object?>(null);
+
   Object? currentValue;
   int timestamp = 0;
 
@@ -125,6 +127,7 @@ class NT4Subscription {
     for (var listener in _listeners) {
       listener(value, timestamp);
     }
+    this.value.value = value;
     currentValue = value;
     this.timestamp = timestamp;
   }

--- a/lib/services/nt_connection.dart
+++ b/lib/services/nt_connection.dart
@@ -86,8 +86,16 @@ class NTConnection {
     _ntClient.addTopicAnnounceListener(onAnnounce);
   }
 
-  void removeTopicAnnounceListener(Function(NT4Topic topic) onUnannounce) {
-    _ntClient.removeTopicAnnounceListener(onUnannounce);
+  void removeTopicAnnounceListener(Function(NT4Topic topic) onAnnounce) {
+    _ntClient.removeTopicAnnounceListener(onAnnounce);
+  }
+
+  void addTopicUnannounceListener(Function(NT4Topic topic) onUnannounce) {
+    _ntClient.addTopicUnannounceListener(onUnannounce);
+  }
+
+  void removeTopicUnannounceListener(Function(NT4Topic topic) onUnannounce) {
+    _ntClient.removeTopicUnannounceListener(onUnannounce);
   }
 
   Future<T?>? subscribeAndRetrieveData<T>(String topic,

--- a/lib/services/nt_widget_builder.dart
+++ b/lib/services/nt_widget_builder.dart
@@ -203,7 +203,7 @@ class NTWidgetBuilder {
         defaultHeight: 2);
 
     registerWithAlias(
-        names: {EncoderWidget.widgetType, "Quadrature Encoder"},
+        names: {EncoderWidget.widgetType, 'Quadrature Encoder'},
         model: EncoderModel.new,
         widget: EncoderWidget.new,
         fromJson: EncoderModel.fromJson,

--- a/lib/services/nt_widget_builder.dart
+++ b/lib/services/nt_widget_builder.dart
@@ -385,7 +385,7 @@ class NTWidgetBuilder {
       );
     }
 
-    return NTWidgetModel.createDefault(
+    return SingleTopicNTWidgetModel.createDefault(
       ntConnection: ntConnection,
       preferences: preferences,
       type: type,
@@ -414,7 +414,7 @@ class NTWidgetBuilder {
 
     onWidgetTypeNotFound
         ?.call('Unknown widget type: \'$type\', defaulting to Empty Model.');
-    return NTWidgetModel.createDefault(
+    return SingleTopicNTWidgetModel.createDefault(
       ntConnection: ntConnection,
       preferences: preferences,
       type: type,
@@ -513,7 +513,7 @@ class NTWidgetBuilder {
     }
   }
 
-  static void registerWithAlias<ModelType extends NTWidgetModel,
+  static void registerWithAlias<ModelType extends SingleTopicNTWidgetModel,
       WidgetType extends NTWidget>({
     required Set<String> names,
     required NTModelProvider model,

--- a/lib/services/shuffleboard_nt_listener.dart
+++ b/lib/services/shuffleboard_nt_listener.dart
@@ -45,16 +45,16 @@ class ShuffleboardNTListener {
   }
 
   void initializeListeners() {
-    selectedSubscription.periodicStream(yieldAll: false).listen((data) {
-      if (data is! String?) {
+    selectedSubscription.addListener(() {
+      if (selectedSubscription.value is! String?) {
         return;
       }
 
-      if (data != previousSelection && data != null) {
-        _handleTabChange(data);
+      if (selectedSubscription.value != null) {
+        _handleTabChange(selectedSubscription.value! as String);
       }
 
-      previousSelection = data;
+      previousSelection = selectedSubscription.value! as String;
     });
 
     // Also clear data when connected in case if threads auto populate json after disconnection

--- a/lib/widgets/draggable_containers/models/nt_widget_container_model.dart
+++ b/lib/widgets/draggable_containers/models/nt_widget_container_model.dart
@@ -319,7 +319,9 @@ class NTWidgetContainerModel extends WidgetContainerModel {
       preferences,
       type,
       childModel.topic,
-      dataType: childModel.dataType,
+      dataType: (childModel is SingleTopicNTWidgetModel)
+          ? cast<SingleTopicNTWidgetModel>(childModel).dataType
+          : "Unkown",
       period: (type != 'Graph')
           ? childModel.period
           : preferences.getDouble(PrefKeys.defaultGraphPeriod) ??

--- a/lib/widgets/draggable_containers/models/nt_widget_container_model.dart
+++ b/lib/widgets/draggable_containers/models/nt_widget_container_model.dart
@@ -321,7 +321,7 @@ class NTWidgetContainerModel extends WidgetContainerModel {
       childModel.topic,
       dataType: (childModel is SingleTopicNTWidgetModel)
           ? cast<SingleTopicNTWidgetModel>(childModel).dataType
-          : "Unkown",
+          : 'Unkown',
       period: (type != 'Graph')
           ? childModel.period
           : preferences.getDouble(PrefKeys.defaultGraphPeriod) ??

--- a/lib/widgets/network_tree/networktables_tree.dart
+++ b/lib/widgets/network_tree/networktables_tree.dart
@@ -37,7 +37,7 @@ class NetworkTableTree extends StatefulWidget {
     required this.hideMetadata,
     this.onDragUpdate,
     this.onDragEnd,
-    this.searchQuery = "",
+    this.searchQuery = '',
   });
 
   @override

--- a/lib/widgets/network_tree/networktables_tree_row.dart
+++ b/lib/widgets/network_tree/networktables_tree_row.dart
@@ -113,8 +113,10 @@ class NetworkTableTreeRow {
     children.clear();
   }
 
-  static NTWidgetModel? getNTWidgetFromTopic(NTConnection ntConnection,
-      SharedPreferences preferences, NT4Topic ntTopic) {
+  static SingleTopicNTWidgetModel? getNTWidgetFromTopic(
+      NTConnection ntConnection,
+      SharedPreferences preferences,
+      NT4Topic ntTopic) {
     switch (ntTopic.type) {
       case NT4TypeStr.kFloat64:
       case NT4TypeStr.kInt:
@@ -192,7 +194,11 @@ class NetworkTableTreeRow {
     }
 
     return NTWidgetBuilder.buildNTModelFromType(
-        ntConnection, preferences, type, topic);
+      ntConnection,
+      preferences,
+      type,
+      topic,
+    );
   }
 
   Future<List<NTWidgetContainerModel>?> getListLayoutChildren() async {

--- a/lib/widgets/nt_widgets/multi-topic/accelerometer.dart
+++ b/lib/widgets/nt_widgets/multi-topic/accelerometer.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class AccelerometerModel extends NTWidgetModel {
+class AccelerometerModel extends SingleTopicNTWidgetModel {
   @override
   String type = AccelerometerWidget.widgetType;
 
@@ -63,11 +63,10 @@ class AccelerometerWidget extends NTWidget {
   Widget build(BuildContext context) {
     AccelerometerModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-        stream: model.valueSubscription.periodicStream(yieldAll: false),
-        initialData: model.ntConnection.getLastAnnouncedValue(model.valueTopic),
-        builder: (context, snapshot) {
-          double value = tryCast(snapshot.data) ?? 0.0;
+    return ValueListenableBuilder(
+        valueListenable: model.valueSubscription.value,
+        builder: (context, data, child) {
+          double value = tryCast(data) ?? 0.0;
 
           return Row(
             children: [

--- a/lib/widgets/nt_widgets/multi-topic/accelerometer.dart
+++ b/lib/widgets/nt_widgets/multi-topic/accelerometer.dart
@@ -6,20 +6,24 @@ import 'package:provider/provider.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class AccelerometerModel extends SingleTopicNTWidgetModel {
+class AccelerometerModel extends MultiTopicNTWidgetModel {
   @override
   String type = AccelerometerWidget.widgetType;
 
   late NT4Subscription _valueSubscription;
+  NT4Subscription get valueSubscription => _valueSubscription;
 
   String get valueTopic => '$topic/Value';
+
+  @override
+  List<NT4Subscription> get subscriptions => [_valueSubscription];
 
   AccelerometerModel({
     required super.ntConnection,
     required super.preferences,
     required super.topic,
-    super.dataType,
     super.period,
+    super.dataType,
   }) : super();
 
   AccelerometerModel.fromJson({
@@ -29,29 +33,9 @@ class AccelerometerModel extends SingleTopicNTWidgetModel {
   }) : super.fromJson();
 
   @override
-  void init() {
-    super.init();
-
+  void initializeSubscriptions() {
     _valueSubscription = ntConnection.subscribe(valueTopic, super.period);
   }
-
-  @override
-  void resetSubscription() {
-    ntConnection.unSubscribe(_valueSubscription);
-
-    _valueSubscription = ntConnection.subscribe(valueTopic, super.period);
-
-    super.resetSubscription();
-  }
-
-  @override
-  void unSubscribe() {
-    ntConnection.unSubscribe(_valueSubscription);
-
-    super.unSubscribe();
-  }
-
-  NT4Subscription get valueSubscription => _valueSubscription;
 }
 
 class AccelerometerWidget extends NTWidget {
@@ -64,7 +48,7 @@ class AccelerometerWidget extends NTWidget {
     AccelerometerModel model = cast(context.watch<NTWidgetModel>());
 
     return ValueListenableBuilder(
-        valueListenable: model.valueSubscription.value,
+        valueListenable: model.valueSubscription,
         builder: (context, data, child) {
           double value = tryCast(data) ?? 0.0;
 

--- a/lib/widgets/nt_widgets/multi-topic/basic_swerve_drive.dart
+++ b/lib/widgets/nt_widgets/multi-topic/basic_swerve_drive.dart
@@ -64,10 +64,10 @@ class BasicSwerveModel extends MultiTopicNTWidgetModel {
     required super.ntConnection,
     required super.preferences,
     required super.topic,
-    super.dataType,
     bool showRobotRotation = true,
     String rotationUnit = 'Radians',
     super.period,
+    super.dataType,
   })  : _rotationUnit = rotationUnit,
         _showRobotRotation = showRobotRotation,
         super();
@@ -192,49 +192,6 @@ class BasicSwerveModel extends MultiTopicNTWidgetModel {
     ];
   }
 
-  @override
-  List<Object> getCurrentData() {
-    double frontLeftAngle =
-        tryCast(ntConnection.getLastAnnouncedValue(frontLeftAngleTopic)) ?? 0.0;
-    double frontLeftVelocity =
-        tryCast(ntConnection.getLastAnnouncedValue(frontLeftVelocityTopic)) ??
-            0.0;
-
-    double frontRightAngle =
-        tryCast(ntConnection.getLastAnnouncedValue(frontRightAngleTopic)) ??
-            0.0;
-    double frontRightVelocity =
-        tryCast(ntConnection.getLastAnnouncedValue(frontRightVelocityTopic)) ??
-            0.0;
-
-    double backLeftAngle =
-        tryCast(ntConnection.getLastAnnouncedValue(backLeftAngleTopic)) ?? 0.0;
-    double backLeftVelocity =
-        tryCast(ntConnection.getLastAnnouncedValue(backLeftVelocityTopic)) ??
-            0.0;
-
-    double backRightAngle =
-        tryCast(ntConnection.getLastAnnouncedValue(backRightAngleTopic)) ?? 0.0;
-    double backRightVelocity =
-        tryCast(ntConnection.getLastAnnouncedValue(backRightVelocityTopic)) ??
-            0.0;
-
-    double robotAngle =
-        tryCast(ntConnection.getLastAnnouncedValue(robotAngleTopic)) ?? 0.0;
-
-    return [
-      frontLeftAngle,
-      frontLeftVelocity,
-      frontRightAngle,
-      frontRightVelocity,
-      backLeftAngle,
-      backLeftVelocity,
-      backRightAngle,
-      backRightVelocity,
-      robotAngle,
-    ];
-  }
-
   get showRobotRotation => _showRobotRotation;
 
   set showRobotRotation(value) {
@@ -260,30 +217,29 @@ class SwerveDriveWidget extends NTWidget {
     BasicSwerveModel model = cast(context.watch<NTWidgetModel>());
 
     return ListenableBuilder(
-      listenable: Listenable.merge(model.subscriptions.map((e) => e.value)),
+      listenable: Listenable.merge(model.subscriptions),
       builder: (context, child) {
         double frontLeftAngle =
-            tryCast(model.frontLeftAngleSubscription.value.value) ?? 0.0;
+            tryCast(model.frontLeftAngleSubscription.value) ?? 0.0;
         double frontLeftVelocity =
-            tryCast(model.frontLeftVelocitySubscription.value.value) ?? 0.0;
+            tryCast(model.frontLeftVelocitySubscription.value) ?? 0.0;
 
         double frontRightAngle =
-            tryCast(model.frontRightAngleSubscription.value.value) ?? 0.0;
+            tryCast(model.frontRightAngleSubscription.value) ?? 0.0;
         double frontRightVelocity =
-            tryCast(model.frontRightVelocitySubscription.value.value) ?? 0.0;
+            tryCast(model.frontRightVelocitySubscription.value) ?? 0.0;
 
         double backLeftAngle =
-            tryCast(model.backLeftAngleSubscription.value.value) ?? 0.0;
+            tryCast(model.backLeftAngleSubscription.value) ?? 0.0;
         double backLeftVelocity =
-            tryCast(model.backLeftVelocitySubscription.value.value) ?? 0.0;
+            tryCast(model.backLeftVelocitySubscription.value) ?? 0.0;
 
         double backRightAngle =
-            tryCast(model.backRightAngleSubscription.value.value) ?? 0.0;
+            tryCast(model.backRightAngleSubscription.value) ?? 0.0;
         double backRightVelocity =
-            tryCast(model.backRightVelocitySubscription.value.value) ?? 0.0;
+            tryCast(model.backRightVelocitySubscription.value) ?? 0.0;
 
-        double robotAngle =
-            tryCast(model.robotAngleSubscription.value.value) ?? 0.0;
+        double robotAngle = tryCast(model.robotAngleSubscription.value) ?? 0.0;
 
         if (model.rotationUnit == 'Degrees') {
           frontLeftAngle = radians(frontLeftAngle);

--- a/lib/widgets/nt_widgets/multi-topic/basic_swerve_drive.dart
+++ b/lib/widgets/nt_widgets/multi-topic/basic_swerve_drive.dart
@@ -6,10 +6,11 @@ import 'package:dot_cast/dot_cast.dart';
 import 'package:provider/provider.dart';
 import 'package:vector_math/vector_math_64.dart' show radians;
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class BasicSwerveModel extends NTWidgetModel {
+class BasicSwerveModel extends MultiTopicNTWidgetModel {
   @override
   String type = SwerveDriveWidget.widgetType;
 
@@ -31,6 +32,30 @@ class BasicSwerveModel extends NTWidgetModel {
 
   get robotAngleTopic => '$topic/Robot Angle';
 
+  late NT4Subscription frontLeftAngleSubscription;
+  late NT4Subscription frontLeftVelocitySubscription;
+  late NT4Subscription frontRightAngleSubscription;
+  late NT4Subscription frontRightVelocitySubscription;
+  late NT4Subscription backLeftAngleSubscription;
+  late NT4Subscription backLeftVelocitySubscription;
+  late NT4Subscription backRightAngleSubscription;
+  late NT4Subscription backRightVelocitySubscription;
+
+  late NT4Subscription robotAngleSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        frontLeftAngleSubscription,
+        frontLeftVelocitySubscription,
+        frontRightAngleSubscription,
+        frontRightVelocitySubscription,
+        backLeftAngleSubscription,
+        backLeftVelocitySubscription,
+        backRightAngleSubscription,
+        backRightVelocitySubscription,
+        robotAngleSubscription,
+      ];
+
   bool _showRobotRotation = true;
 
   String _rotationUnit = 'Radians';
@@ -39,10 +64,10 @@ class BasicSwerveModel extends NTWidgetModel {
     required super.ntConnection,
     required super.preferences,
     required super.topic,
+    super.dataType,
     bool showRobotRotation = true,
     String rotationUnit = 'Radians',
     super.period,
-    super.dataType,
   })  : _rotationUnit = rotationUnit,
         _showRobotRotation = showRobotRotation,
         super();
@@ -54,6 +79,46 @@ class BasicSwerveModel extends NTWidgetModel {
   }) : super.fromJson(jsonData: jsonData) {
     _showRobotRotation = tryCast(jsonData['show_robot_rotation']) ?? true;
     _rotationUnit = tryCast(jsonData['rotation_unit']) ?? 'Degrees';
+  }
+
+  @override
+  void init() {
+    initSubscriptions();
+
+    super.init();
+  }
+
+  void initSubscriptions() {
+    frontLeftAngleSubscription =
+        ntConnection.subscribe(frontLeftAngleTopic, super.period);
+    frontLeftVelocitySubscription =
+        ntConnection.subscribe(frontLeftVelocityTopic, super.period);
+    frontRightAngleSubscription =
+        ntConnection.subscribe(frontRightAngleTopic, super.period);
+    frontRightVelocitySubscription =
+        ntConnection.subscribe(frontRightVelocityTopic, super.period);
+    backLeftAngleSubscription =
+        ntConnection.subscribe(backLeftAngleTopic, super.period);
+    backLeftVelocitySubscription =
+        ntConnection.subscribe(backLeftVelocityTopic, super.period);
+    backRightAngleSubscription =
+        ntConnection.subscribe(backRightAngleTopic, super.period);
+    backRightVelocitySubscription =
+        ntConnection.subscribe(backRightVelocityTopic, super.period);
+
+    robotAngleSubscription =
+        ntConnection.subscribe(robotAngleTopic, super.period);
+  }
+
+  @override
+  void resetSubscription() {
+    for (NT4Subscription subscription in subscriptions) {
+      ntConnection.unSubscribe(subscription);
+    }
+
+    initSubscriptions();
+
+    super.resetSubscription();
   }
 
   @override
@@ -194,40 +259,31 @@ class SwerveDriveWidget extends NTWidget {
   Widget build(BuildContext context) {
     BasicSwerveModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
-      builder: (context, snapshot) {
-        double frontLeftAngle = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.frontLeftAngleTopic)) ??
-            0.0;
-        double frontLeftVelocity = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.frontLeftVelocityTopic)) ??
-            0.0;
+    return ListenableBuilder(
+      listenable: Listenable.merge(model.subscriptions.map((e) => e.value)),
+      builder: (context, child) {
+        double frontLeftAngle =
+            tryCast(model.frontLeftAngleSubscription.value.value) ?? 0.0;
+        double frontLeftVelocity =
+            tryCast(model.frontLeftVelocitySubscription.value.value) ?? 0.0;
 
-        double frontRightAngle = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.frontRightAngleTopic)) ??
-            0.0;
-        double frontRightVelocity = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.frontRightVelocityTopic)) ??
-            0.0;
+        double frontRightAngle =
+            tryCast(model.frontRightAngleSubscription.value.value) ?? 0.0;
+        double frontRightVelocity =
+            tryCast(model.frontRightVelocitySubscription.value.value) ?? 0.0;
 
-        double backLeftAngle = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.backLeftAngleTopic)) ??
-            0.0;
-        double backLeftVelocity = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.backLeftVelocityTopic)) ??
-            0.0;
+        double backLeftAngle =
+            tryCast(model.backLeftAngleSubscription.value.value) ?? 0.0;
+        double backLeftVelocity =
+            tryCast(model.backLeftVelocitySubscription.value.value) ?? 0.0;
 
-        double backRightAngle = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.backRightAngleTopic)) ??
-            0.0;
-        double backRightVelocity = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.backRightVelocityTopic)) ??
-            0.0;
+        double backRightAngle =
+            tryCast(model.backRightAngleSubscription.value.value) ?? 0.0;
+        double backRightVelocity =
+            tryCast(model.backRightVelocitySubscription.value.value) ?? 0.0;
 
-        double robotAngle = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.robotAngleTopic)) ??
-            0.0;
+        double robotAngle =
+            tryCast(model.robotAngleSubscription.value.value) ?? 0.0;
 
         if (model.rotationUnit == 'Degrees') {
           frontLeftAngle = radians(frontLeftAngle);

--- a/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
+++ b/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
@@ -9,7 +9,7 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart'
 import 'package:elastic_dashboard/widgets/mjpeg.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class CameraStreamModel extends NTWidgetModel {
+class CameraStreamModel extends SingleTopicNTWidgetModel {
   @override
   String type = CameraStreamWidget.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
+++ b/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
@@ -4,16 +4,22 @@ import 'package:flutter/services.dart';
 import 'package:dot_cast/dot_cast.dart';
 import 'package:provider/provider.dart';
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/custom_loading_indicator.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart';
 import 'package:elastic_dashboard/widgets/mjpeg.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class CameraStreamModel extends SingleTopicNTWidgetModel {
+class CameraStreamModel extends MultiTopicNTWidgetModel {
   @override
   String type = CameraStreamWidget.widgetType;
 
   String get streamsTopic => '$topic/streams';
+
+  late NT4Subscription streamsSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [streamsSubscription];
 
   int? _quality;
   int? _fps;
@@ -87,6 +93,11 @@ class CameraStreamModel extends SingleTopicNTWidgetModel {
     if (resolution != null && resolution.length > 1) {
       _resolution = Size(resolution[0].toDouble(), resolution[1].toDouble());
     }
+  }
+
+  @override
+  void initializeSubscriptions() {
+    streamsSubscription = ntConnection.subscribe(streamsTopic, super.period);
   }
 
   @override
@@ -235,18 +246,6 @@ class CameraStreamModel extends SingleTopicNTWidgetModel {
     mjpegStream?.dispose();
     mjpegStream = null;
   }
-
-  @override
-  List<Object> getCurrentData() {
-    List<Object?> rawStreams =
-        tryCast(ntConnection.getLastAnnouncedValue(streamsTopic)) ?? [];
-    List<String> streams = rawStreams.whereType<String>().toList();
-
-    return [
-      ...streams,
-      ntConnection.isNT4Connected,
-    ];
-  }
 }
 
 class CameraStreamWidget extends NTWidget {
@@ -258,12 +257,11 @@ class CameraStreamWidget extends NTWidget {
   Widget build(BuildContext context) {
     CameraStreamModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
-      builder: (context, snapshot) {
-        List<Object?> rawStreams = tryCast(
-                model.ntConnection.getLastAnnouncedValue(model.streamsTopic)) ??
-            [];
+    return ListenableBuilder(
+      listenable: model.streamsSubscription,
+      builder: (context, child) {
+        List<Object?> rawStreams =
+            tryCast(model.streamsSubscription.value) ?? [];
 
         List<String> streams = [];
         for (Object? stream in rawStreams) {

--- a/lib/widgets/nt_widgets/multi-topic/combo_box_chooser.dart
+++ b/lib/widgets/nt_widgets/multi-topic/combo_box_chooser.dart
@@ -8,7 +8,7 @@ import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class ComboBoxChooserModel extends NTWidgetModel {
+class ComboBoxChooserModel extends SingleTopicNTWidgetModel {
   @override
   String type = ComboBoxChooser.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/command_scheduler.dart
+++ b/lib/widgets/nt_widgets/multi-topic/command_scheduler.dart
@@ -8,7 +8,7 @@ import 'package:provider/provider.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class CommandSchedulerModel extends NTWidgetModel {
+class CommandSchedulerModel extends SingleTopicNTWidgetModel {
   @override
   String type = CommandSchedulerWidget.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/command_scheduler.dart
+++ b/lib/widgets/nt_widgets/multi-topic/command_scheduler.dart
@@ -8,7 +8,7 @@ import 'package:provider/provider.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class CommandSchedulerModel extends SingleTopicNTWidgetModel {
+class CommandSchedulerModel extends MultiTopicNTWidgetModel {
   @override
   String type = CommandSchedulerWidget.widgetType;
 
@@ -17,6 +17,17 @@ class CommandSchedulerModel extends SingleTopicNTWidgetModel {
   String get namesTopicName => '$topic/Names';
   String get idsTopicName => '$topic/Ids';
   String get cancelTopicName => '$topic/Cancel';
+
+  late NT4Subscription namesSubscription;
+  late NT4Subscription idsSubscription;
+  late NT4Subscription cancelSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        namesSubscription,
+        idsSubscription,
+        cancelSubscription,
+      ];
 
   CommandSchedulerModel({
     required super.ntConnection,
@@ -33,6 +44,13 @@ class CommandSchedulerModel extends SingleTopicNTWidgetModel {
   }) : super.fromJson();
 
   @override
+  void initializeSubscriptions() {
+    namesSubscription = ntConnection.subscribe(namesTopicName, super.period);
+    idsSubscription = ntConnection.subscribe(idsTopicName, super.period);
+    cancelSubscription = ntConnection.subscribe(cancelTopicName, super.period);
+  }
+
+  @override
   void resetSubscription() {
     _cancelTopic = null;
 
@@ -40,10 +58,8 @@ class CommandSchedulerModel extends SingleTopicNTWidgetModel {
   }
 
   void cancelCommand(int id) {
-    List<Object?> currentCancellationsRaw = ntConnection
-            .getLastAnnouncedValue(cancelTopicName)
-            ?.tryCast<List<Object?>>() ??
-        [];
+    List<Object?> currentCancellationsRaw =
+        cancelSubscription.value?.tryCast<List<Object?>>() ?? [];
 
     List<int> currentCancellations =
         currentCancellationsRaw.whereType<int>().toList();
@@ -59,24 +75,6 @@ class CommandSchedulerModel extends SingleTopicNTWidgetModel {
 
     ntConnection.updateDataFromTopic(_cancelTopic!, currentCancellations);
   }
-
-  @override
-  List<Object> getCurrentData() {
-    List<Object?> rawNames = ntConnection
-            .getLastAnnouncedValue(namesTopicName)
-            ?.tryCast<List<Object?>>() ??
-        [];
-
-    List<Object?> rawIds = ntConnection
-            .getLastAnnouncedValue(idsTopicName)
-            ?.tryCast<List<Object?>>() ??
-        [];
-
-    List<String> names = rawNames.whereType<String>().toList();
-    List<int> ids = rawIds.whereType<int>().toList();
-
-    return [...names, ...ids];
-  }
 }
 
 class CommandSchedulerWidget extends NTWidget {
@@ -88,18 +86,14 @@ class CommandSchedulerWidget extends NTWidget {
   Widget build(BuildContext context) {
     CommandSchedulerModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
-      builder: (context, snapshot) {
-        List<Object?> rawNames = model.ntConnection
-                .getLastAnnouncedValue(model.namesTopicName)
-                ?.tryCast<List<Object?>>() ??
-            [];
+    return ListenableBuilder(
+      listenable: Listenable.merge(model.subscriptions),
+      builder: (context, child) {
+        List<Object?> rawNames =
+            model.namesSubscription.value?.tryCast<List<Object?>>() ?? [];
 
-        List<Object?> rawIds = model.ntConnection
-                .getLastAnnouncedValue(model.idsTopicName)
-                ?.tryCast<List<Object?>>() ??
-            [];
+        List<Object?> rawIds =
+            model.idsSubscription.value?.tryCast<List<Object?>>() ?? [];
 
         List<String> names = rawNames.whereType<String>().toList();
         List<int> ids = rawIds.whereType<int>().toList();

--- a/lib/widgets/nt_widgets/multi-topic/command_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/command_widget.dart
@@ -7,7 +7,7 @@ import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class CommandModel extends NTWidgetModel {
+class CommandModel extends SingleTopicNTWidgetModel {
   @override
   String type = CommandWidget.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/command_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/command_widget.dart
@@ -97,78 +97,77 @@ class CommandWidget extends NTWidget {
   Widget build(BuildContext context) {
     CommandModel model = cast(context.watch<NTWidgetModel>());
 
-    return ListenableBuilder(
-      listenable: Listenable.merge(model.subscriptions),
-      builder: (context, child) {
-        bool running =
-            model.runningSubscription.value?.tryCast<bool>() ?? false;
-        String name =
-            model.nameSubscription.value?.tryCast<String>() ?? 'Unknown';
+    String buttonText = model.topic.substring(model.topic.lastIndexOf('/') + 1);
 
-        String buttonText =
-            model.topic.substring(model.topic.lastIndexOf('/') + 1);
+    ThemeData theme = Theme.of(context);
 
-        ThemeData theme = Theme.of(context);
+    return Column(
+      children: [
+        Visibility(
+          visible: model.showType,
+          child: ValueListenableBuilder(
+              valueListenable: model.nameSubscription,
+              builder: (context, data, child) {
+                String name = tryCast(data) ?? 'Unknown';
 
-        return Column(
-          children: [
-            Visibility(
-              visible: model.showType,
-              child: Text('Type: $name',
-                  style: theme.textTheme.bodySmall,
-                  overflow: TextOverflow.ellipsis),
-            ),
-            const SizedBox(height: 10),
-            GestureDetector(
-              onTapUp: (_) {
-                bool publishTopic = model.runningTopic == null;
+                return Text('Type: $name',
+                    style: theme.textTheme.bodySmall,
+                    overflow: TextOverflow.ellipsis);
+              }),
+        ),
+        const SizedBox(height: 10),
+        GestureDetector(
+          onTapUp: (_) {
+            bool publishTopic = model.runningTopic == null;
 
-                model.runningTopic ??=
-                    model.ntConnection.getTopicFromName(model.runningTopicName);
+            model.runningTopic ??=
+                model.ntConnection.getTopicFromName(model.runningTopicName);
 
-                if (model.runningTopic == null) {
-                  return;
-                }
+            if (model.runningTopic == null) {
+              return;
+            }
 
-                if (publishTopic) {
-                  model.ntConnection.publishTopic(model.runningTopic!);
-                }
+            if (publishTopic) {
+              model.ntConnection.publishTopic(model.runningTopic!);
+            }
 
-                // Prevents widget from locking up if double pressed fast enough
-                bool running = model.ntConnection
-                        .getLastAnnouncedValue(model.runningTopicName)
-                        ?.tryCast<bool>() ??
-                    false;
+            // Prevents widget from locking up if double pressed fast enough
+            bool running =
+                model.runningSubscription.value?.tryCast<bool>() ?? false;
 
-                model.ntConnection
-                    .updateDataFromTopic(model.runningTopic!, !running);
-              },
-              child: AnimatedContainer(
-                duration: const Duration(milliseconds: 50),
-                padding:
-                    const EdgeInsets.symmetric(horizontal: 8.0, vertical: 4.0),
-                decoration: BoxDecoration(
-                  borderRadius: BorderRadius.circular(8.0),
-                  boxShadow: const [
-                    BoxShadow(
-                      offset: Offset(2, 2),
-                      blurRadius: 10.0,
-                      spreadRadius: -5,
-                      color: Colors.black,
-                    ),
-                  ],
-                  color: (running)
-                      ? theme.colorScheme.primaryContainer
-                      : const Color.fromARGB(255, 50, 50, 50),
-                ),
-                child: Text(buttonText,
-                    style: theme.textTheme.bodyLarge,
-                    overflow: TextOverflow.ellipsis),
-              ),
-            ),
-          ],
-        );
-      },
+            model.ntConnection
+                .updateDataFromTopic(model.runningTopic!, !running);
+          },
+          child: ValueListenableBuilder(
+              valueListenable: model.runningSubscription,
+              builder: (context, data, child) {
+                bool running = tryCast(data) ?? false;
+
+                return AnimatedContainer(
+                  duration: const Duration(milliseconds: 50),
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 8.0, vertical: 4.0),
+                  decoration: BoxDecoration(
+                    borderRadius: BorderRadius.circular(8.0),
+                    boxShadow: const [
+                      BoxShadow(
+                        offset: Offset(2, 2),
+                        blurRadius: 10.0,
+                        spreadRadius: -5,
+                        color: Colors.black,
+                      ),
+                    ],
+                    color: (running)
+                        ? theme.colorScheme.primaryContainer
+                        : const Color.fromARGB(255, 50, 50, 50),
+                  ),
+                  child: Text(buttonText,
+                      style: theme.textTheme.bodyLarge,
+                      overflow: TextOverflow.ellipsis),
+                );
+              }),
+        ),
+      ],
     );
   }
 }

--- a/lib/widgets/nt_widgets/multi-topic/command_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/command_widget.dart
@@ -7,14 +7,23 @@ import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class CommandModel extends SingleTopicNTWidgetModel {
+class CommandModel extends MultiTopicNTWidgetModel {
   @override
   String type = CommandWidget.widgetType;
 
-  NT4Topic? runningTopic;
-
   String get runningTopicName => '$topic/running';
   String get nameTopicName => '$topic/name';
+
+  late NT4Subscription runningSubscription;
+  late NT4Subscription nameSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        runningSubscription,
+        nameSubscription,
+      ];
+
+  NT4Topic? runningTopic;
 
   bool _showType = true;
 
@@ -44,6 +53,13 @@ class CommandModel extends SingleTopicNTWidgetModel {
   }
 
   @override
+  void initializeSubscriptions() {
+    runningSubscription =
+        ntConnection.subscribe(runningTopicName, super.period);
+    nameSubscription = ntConnection.subscribe(nameTopicName, super.period);
+  }
+
+  @override
   void resetSubscription() {
     runningTopic = null;
 
@@ -70,18 +86,6 @@ class CommandModel extends SingleTopicNTWidgetModel {
       ),
     ];
   }
-
-  @override
-  List<Object> getCurrentData() {
-    bool running =
-        ntConnection.getLastAnnouncedValue(runningTopicName)?.tryCast<bool>() ??
-            false;
-    String name =
-        ntConnection.getLastAnnouncedValue(nameTopicName)?.tryCast<String>() ??
-            'Unknown';
-
-    return [running, name];
-  }
 }
 
 class CommandWidget extends NTWidget {
@@ -93,17 +97,13 @@ class CommandWidget extends NTWidget {
   Widget build(BuildContext context) {
     CommandModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
-      builder: (context, snapshot) {
-        bool running = model.ntConnection
-                .getLastAnnouncedValue(model.runningTopicName)
-                ?.tryCast<bool>() ??
-            false;
-        String name = model.ntConnection
-                .getLastAnnouncedValue(model.nameTopicName)
-                ?.tryCast<String>() ??
-            'Unknown';
+    return ListenableBuilder(
+      listenable: Listenable.merge(model.subscriptions),
+      builder: (context, child) {
+        bool running =
+            model.runningSubscription.value?.tryCast<bool>() ?? false;
+        String name =
+            model.nameSubscription.value?.tryCast<String>() ?? 'Unknown';
 
         String buttonText =
             model.topic.substring(model.topic.lastIndexOf('/') + 1);

--- a/lib/widgets/nt_widgets/multi-topic/differential_drive.dart
+++ b/lib/widgets/nt_widgets/multi-topic/differential_drive.dart
@@ -9,7 +9,7 @@ import 'package:syncfusion_flutter_gauges/gauges.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class DifferentialDriveModel extends NTWidgetModel {
+class DifferentialDriveModel extends SingleTopicNTWidgetModel {
   @override
   String type = DifferentialDrive.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/differential_drive.dart
+++ b/lib/widgets/nt_widgets/multi-topic/differential_drive.dart
@@ -9,12 +9,21 @@ import 'package:syncfusion_flutter_gauges/gauges.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class DifferentialDriveModel extends SingleTopicNTWidgetModel {
+class DifferentialDriveModel extends MultiTopicNTWidgetModel {
   @override
   String type = DifferentialDrive.widgetType;
 
   String get leftSpeedTopicName => '$topic/Left Motor Speed';
   String get rightSpeedTopicName => '$topic/Right Motor Speed';
+
+  late NT4Subscription leftSpeedSubscription;
+  late NT4Subscription rightSpeedSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        leftSpeedSubscription,
+        rightSpeedSubscription,
+      ];
 
   NT4Topic? leftSpeedTopic;
   NT4Topic? rightSpeedTopic;
@@ -22,8 +31,8 @@ class DifferentialDriveModel extends SingleTopicNTWidgetModel {
   double _leftSpeedPreviousValue = 0.0;
   double _rightSpeedPreviousValue = 0.0;
 
-  double _leftSpeedCurrentValue = 0.0;
-  double _rightSpeedCurrentValue = 0.0;
+  ValueNotifier<double> leftSpeedCurrentValue = ValueNotifier<double>(0.0);
+  ValueNotifier<double> rightSpeedCurrentValue = ValueNotifier<double>(0.0);
 
   get leftSpeedPreviousValue => _leftSpeedPreviousValue;
 
@@ -32,14 +41,6 @@ class DifferentialDriveModel extends SingleTopicNTWidgetModel {
   get rightSpeedPreviousValue => _rightSpeedPreviousValue;
 
   set rightSpeedPreviousValue(value) => _rightSpeedPreviousValue = value;
-
-  get leftSpeedCurrentValue => _leftSpeedCurrentValue;
-
-  set leftSpeedCurrentValue(value) => _leftSpeedCurrentValue = value;
-
-  get rightSpeedCurrentValue => _rightSpeedCurrentValue;
-
-  set rightSpeedCurrentValue(value) => _rightSpeedCurrentValue = value;
 
   DifferentialDriveModel({
     required super.ntConnection,
@@ -56,34 +57,25 @@ class DifferentialDriveModel extends SingleTopicNTWidgetModel {
   }) : super.fromJson();
 
   @override
+  void initializeSubscriptions() {
+    leftSpeedSubscription =
+        ntConnection.subscribe(leftSpeedTopicName, super.period);
+    rightSpeedSubscription =
+        ntConnection.subscribe(rightSpeedTopicName, super.period);
+  }
+
+  @override
   void resetSubscription() {
     leftSpeedTopic = null;
     rightSpeedTopic = null;
 
     leftSpeedPreviousValue = 0.0;
-    leftSpeedCurrentValue = 0.0;
+    leftSpeedCurrentValue.value = 0.0;
 
-    rightSpeedPreviousValue = 0.0;
-    rightSpeedCurrentValue = 0.0;
+    rightSpeedPreviousValue.value = 0.0;
+    rightSpeedCurrentValue.value = 0.0;
 
     super.resetSubscription();
-  }
-
-  @override
-  List<Object> getCurrentData() {
-    double leftSpeed =
-        tryCast(ntConnection.getLastAnnouncedValue(leftSpeedTopicName)) ?? 0.0;
-    double rightSpeed =
-        tryCast(ntConnection.getLastAnnouncedValue(rightSpeedTopicName)) ?? 0.0;
-
-    return [
-      leftSpeed,
-      rightSpeed,
-      _leftSpeedPreviousValue,
-      _rightSpeedPreviousValue,
-      _leftSpeedCurrentValue,
-      _rightSpeedCurrentValue,
-    ];
   }
 }
 
@@ -96,23 +88,23 @@ class DifferentialDrive extends NTWidget {
   Widget build(BuildContext context) {
     DifferentialDriveModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
-      builder: (context, snapshot) {
-        double leftSpeed = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.leftSpeedTopicName)) ??
-            0.0;
-        double rightSpeed = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.rightSpeedTopicName)) ??
-            0.0;
+    return ListenableBuilder(
+      listenable: Listenable.merge([
+        ...model.subscriptions,
+        model.leftSpeedCurrentValue,
+        model.rightSpeedCurrentValue,
+      ]),
+      builder: (context, child) {
+        double leftSpeed = tryCast(model.leftSpeedSubscription.value) ?? 0.0;
+        double rightSpeed = tryCast(model.rightSpeedSubscription.value) ?? 0.0;
 
         if (leftSpeed != model.leftSpeedPreviousValue) {
-          model.leftSpeedCurrentValue = leftSpeed;
+          model.leftSpeedCurrentValue.value = leftSpeed;
         }
         model.leftSpeedPreviousValue = leftSpeed;
 
         if (rightSpeed != model.rightSpeedPreviousValue) {
-          model.rightSpeedCurrentValue = rightSpeed;
+          model.rightSpeedCurrentValue.value = rightSpeed;
         }
         model.rightSpeedPreviousValue = rightSpeed;
 
@@ -128,7 +120,7 @@ class DifferentialDrive extends NTWidget {
               tickPosition: LinearElementPosition.inside,
               markerPointers: [
                 LinearShapePointer(
-                  value: model.leftSpeedCurrentValue.clamp(-1.0, 1.0),
+                  value: model.leftSpeedCurrentValue.value.clamp(-1.0, 1.0),
                   color: Theme.of(context).colorScheme.primary,
                   height: 12.5,
                   width: 12.5,
@@ -137,7 +129,7 @@ class DifferentialDrive extends NTWidget {
                   position: LinearElementPosition.outside,
                   dragBehavior: LinearMarkerDragBehavior.free,
                   onChanged: (value) {
-                    model.leftSpeedCurrentValue = value;
+                    model.leftSpeedCurrentValue.value = value;
                   },
                   onChangeEnd: (value) {
                     bool publishTopic = model.leftSpeedTopic == null;
@@ -181,9 +173,10 @@ class DifferentialDrive extends NTWidget {
                     height: sideLength,
                     child: CustomPaint(
                       painter: _DifferentialDrivePainter(
-                        leftSpeed: model.leftSpeedCurrentValue.clamp(-1.0, 1.0),
+                        leftSpeed:
+                            model.leftSpeedCurrentValue.value.clamp(-1.0, 1.0),
                         rightSpeed:
-                            model.rightSpeedCurrentValue.clamp(-1.0, 1.0),
+                            model.rightSpeedCurrentValue.value.clamp(-1.0, 1.0),
                       ),
                     ),
                   );
@@ -200,7 +193,7 @@ class DifferentialDrive extends NTWidget {
               tickPosition: LinearElementPosition.outside,
               markerPointers: [
                 LinearShapePointer(
-                  value: model.rightSpeedCurrentValue.clamp(-1.0, 1.0),
+                  value: model.rightSpeedCurrentValue.value.clamp(-1.0, 1.0),
                   color: Theme.of(context).colorScheme.primary,
                   height: 12.5,
                   width: 12.5,
@@ -209,7 +202,7 @@ class DifferentialDrive extends NTWidget {
                   position: LinearElementPosition.inside,
                   dragBehavior: LinearMarkerDragBehavior.free,
                   onChanged: (value) {
-                    model.rightSpeedCurrentValue = value;
+                    model.rightSpeedCurrentValue.value = value;
                   },
                   onChangeEnd: (value) {
                     bool publishTopic = model.rightSpeedTopic == null;

--- a/lib/widgets/nt_widgets/multi-topic/differential_drive.dart
+++ b/lib/widgets/nt_widgets/multi-topic/differential_drive.dart
@@ -148,7 +148,8 @@ class DifferentialDrive extends NTWidget {
                     model.ntConnection.updateDataFromTopic(
                         model.leftSpeedTopic!, model.leftSpeedCurrentValue);
 
-                    model.leftSpeedPreviousValue = model.leftSpeedCurrentValue;
+                    model.leftSpeedPreviousValue =
+                        model.leftSpeedCurrentValue.value;
                   },
                 ),
               ],
@@ -222,7 +223,7 @@ class DifferentialDrive extends NTWidget {
                         model.rightSpeedTopic!, model.rightSpeedCurrentValue);
 
                     model.rightSpeedPreviousValue =
-                        model.rightSpeedCurrentValue;
+                        model.rightSpeedCurrentValue.value;
                   },
                 ),
               ],

--- a/lib/widgets/nt_widgets/multi-topic/encoder_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/encoder_widget.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class EncoderModel extends NTWidgetModel {
+class EncoderModel extends SingleTopicNTWidgetModel {
   @override
   String type = EncoderWidget.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/encoder_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/encoder_widget.dart
@@ -52,70 +52,72 @@ class EncoderWidget extends NTWidget {
   Widget build(BuildContext context) {
     EncoderModel model = cast(context.watch<NTWidgetModel>());
 
-    return ListenableBuilder(
-      listenable: Listenable.merge(model.subscriptions),
-      builder: (context, child) {
-        double distance = tryCast(model.distanceSubscription.value) ?? 0.0;
-        double speed = tryCast(model.speedSubscription.value) ?? 0.0;
-
-        return Column(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      children: [
+        Row(
           children: [
-            Row(
-              children: [
-                const Text('Distance'),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      border: Border(
-                        bottom: BorderSide(
-                          color: Colors.grey.shade700,
-                          width: 1.5,
-                        ),
-                      ),
-                    ),
-                    child: SelectableText(
-                      distance.toStringAsPrecision(10),
-                      maxLines: 1,
-                      showCursor: true,
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                            overflow: TextOverflow.ellipsis,
-                          ),
+            const Text('Distance'),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Container(
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(
+                      color: Colors.grey.shade700,
+                      width: 1.5,
                     ),
                   ),
                 ),
-              ],
-            ),
-            Row(
-              children: [
-                const Text('Speed'),
-                const SizedBox(width: 10),
-                Expanded(
-                  child: Container(
-                    decoration: BoxDecoration(
-                      border: Border(
-                        bottom: BorderSide(
-                          color: Colors.grey.shade700,
-                          width: 1.5,
-                        ),
-                      ),
-                    ),
-                    child: SelectableText(
-                      speed.toStringAsPrecision(10),
-                      maxLines: 1,
-                      showCursor: true,
-                      style: Theme.of(context).textTheme.bodyLarge?.copyWith(
-                            overflow: TextOverflow.ellipsis,
-                          ),
-                    ),
-                  ),
-                ),
-              ],
+                child: ValueListenableBuilder(
+                    valueListenable: model.distanceSubscription,
+                    builder: (context, value, child) {
+                      double distance = tryCast(value) ?? 0.0;
+                      return SelectableText(
+                        distance.toStringAsPrecision(10),
+                        maxLines: 1,
+                        showCursor: true,
+                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                      );
+                    }),
+              ),
             ),
           ],
-        );
-      },
+        ),
+        Row(
+          children: [
+            const Text('Speed'),
+            const SizedBox(width: 10),
+            Expanded(
+              child: Container(
+                decoration: BoxDecoration(
+                  border: Border(
+                    bottom: BorderSide(
+                      color: Colors.grey.shade700,
+                      width: 1.5,
+                    ),
+                  ),
+                ),
+                child: ValueListenableBuilder(
+                    valueListenable: model.speedSubscription,
+                    builder: (context, value, child) {
+                      double speed = tryCast(value) ?? 0.0;
+                      return SelectableText(
+                        speed.toStringAsPrecision(10),
+                        maxLines: 1,
+                        showCursor: true,
+                        style: Theme.of(context).textTheme.bodyLarge?.copyWith(
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                      );
+                    }),
+              ),
+            ),
+          ],
+        ),
+      ],
     );
   }
 }

--- a/lib/widgets/nt_widgets/multi-topic/field_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/field_widget.dart
@@ -18,7 +18,7 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart'
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class FieldWidgetModel extends NTWidgetModel {
+class FieldWidgetModel extends SingleTopicNTWidgetModel {
   @override
   String type = 'Field';
 
@@ -94,7 +94,7 @@ class FieldWidgetModel extends NTWidgetModel {
 
   get field => _field;
 
-  late String _robotTopicName;
+  String get robotTopicName => '$topic/Robot';
   final List<String> _otherObjectTopics = [];
 
   bool rendered = false;
@@ -160,8 +160,6 @@ class FieldWidgetModel extends NTWidgetModel {
   void init() {
     super.init();
 
-    _robotTopicName = '$topic/Robot';
-
     topicAnnounceListener = (nt4Topic) {
       if (nt4Topic.name.contains(topic) &&
           !nt4Topic.name.contains('Robot') &&
@@ -176,7 +174,6 @@ class FieldWidgetModel extends NTWidgetModel {
 
   @override
   void resetSubscription() {
-    _robotTopicName = '$topic/Robot';
     _otherObjectTopics.clear();
 
     super.resetSubscription();
@@ -387,7 +384,7 @@ class FieldWidgetModel extends NTWidgetModel {
     List<Object> data = [];
 
     List<Object?> robotPositionRaw = ntConnection
-            .getLastAnnouncedValue(_robotTopicName)
+            .getLastAnnouncedValue(robotTopicName)
             ?.tryCast<List<Object?>>() ??
         [];
 
@@ -568,7 +565,7 @@ class FieldWidget extends NTWidget {
       stream: model.multiTopicPeriodicStream,
       builder: (context, snapshot) {
         List<Object?> robotPositionRaw = model.ntConnection
-                .getLastAnnouncedValue(model._robotTopicName)
+                .getLastAnnouncedValue(model.robotTopicName)
                 ?.tryCast<List<Object?>>() ??
             [];
 

--- a/lib/widgets/nt_widgets/multi-topic/field_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/field_widget.dart
@@ -567,6 +567,7 @@ class FieldWidget extends NTWidget {
         }
 
         // Try rebuilding again if the image isn't fully rendered
+        // Can't do it if it's in a unit test cause it causes issues with timers running
         if (!model.rendered &&
             !Platform.environment.containsKey('FLUTTER_TEST')) {
           Future.delayed(const Duration(milliseconds: 100), model.refresh);

--- a/lib/widgets/nt_widgets/multi-topic/field_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/field_widget.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'dart:math';
 
 import 'package:flutter/gestures.dart';
@@ -566,7 +567,8 @@ class FieldWidget extends NTWidget {
         }
 
         // Try rebuilding again if the image isn't fully rendered
-        if (!model.rendered) {
+        if (!model.rendered &&
+            !Platform.environment.containsKey('FLUTTER_TEST')) {
           Future.delayed(const Duration(milliseconds: 100), model.refresh);
         }
 

--- a/lib/widgets/nt_widgets/multi-topic/fms_info.dart
+++ b/lib/widgets/nt_widgets/multi-topic/fms_info.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class FMSInfoModel extends NTWidgetModel {
+class FMSInfoModel extends SingleTopicNTWidgetModel {
   @override
   String type = FMSInfo.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/fms_info.dart
+++ b/lib/widgets/nt_widgets/multi-topic/fms_info.dart
@@ -4,9 +4,10 @@ import 'package:dot_cast/dot_cast.dart';
 import 'package:patterns_canvas/patterns_canvas.dart';
 import 'package:provider/provider.dart';
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class FMSInfoModel extends SingleTopicNTWidgetModel {
+class FMSInfoModel extends MultiTopicNTWidgetModel {
   @override
   String type = FMSInfo.widgetType;
 
@@ -17,6 +18,23 @@ class FMSInfoModel extends SingleTopicNTWidgetModel {
   String get matchTypeTopic => '$topic/MatchType';
   String get replayNumberTopic => '$topic/ReplayNumber';
   String get stationNumberTopic => '$topic/StationNumber';
+
+  late NT4Subscription eventNameSubscription;
+  late NT4Subscription controlDataSubscription;
+  late NT4Subscription allianceSubscription;
+  late NT4Subscription matchNumberSubscription;
+  late NT4Subscription matchTypeSubscription;
+  late NT4Subscription replayNumberSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        eventNameSubscription,
+        controlDataSubscription,
+        allianceSubscription,
+        matchNumberSubscription,
+        matchTypeSubscription,
+        replayNumberSubscription,
+      ];
 
   FMSInfoModel({
     required super.ntConnection,
@@ -33,28 +51,18 @@ class FMSInfoModel extends SingleTopicNTWidgetModel {
   }) : super.fromJson();
 
   @override
-  List<Object> getCurrentData() {
-    String eventName =
-        tryCast(ntConnection.getLastAnnouncedValue(eventNameTopic)) ?? '';
-    int controlData =
-        tryCast(ntConnection.getLastAnnouncedValue(controlDataTopic)) ?? 32;
-    bool redAlliance =
-        tryCast(ntConnection.getLastAnnouncedValue(allianceTopic)) ?? true;
-    int matchNumber =
-        tryCast(ntConnection.getLastAnnouncedValue(matchNumberTopic)) ?? 0;
-    int matchType =
-        tryCast(ntConnection.getLastAnnouncedValue(matchTypeTopic)) ?? 0;
-    int replayNumber =
-        tryCast(ntConnection.getLastAnnouncedValue(replayNumberTopic)) ?? 0;
-
-    return [
-      eventName,
-      controlData,
-      redAlliance,
-      matchNumber,
-      matchType,
-      replayNumber,
-    ];
+  void initializeSubscriptions() {
+    eventNameSubscription =
+        ntConnection.subscribe(eventNameTopic, super.period);
+    controlDataSubscription =
+        ntConnection.subscribe(controlDataTopic, super.period);
+    allianceSubscription = ntConnection.subscribe(allianceTopic, super.period);
+    matchNumberSubscription =
+        ntConnection.subscribe(matchNumberTopic, super.period);
+    matchTypeSubscription =
+        ntConnection.subscribe(matchTypeTopic, super.period);
+    replayNumberSubscription =
+        ntConnection.subscribe(replayNumberTopic, super.period);
   }
 }
 
@@ -91,27 +99,15 @@ class FMSInfo extends NTWidget {
   Widget build(BuildContext context) {
     FMSInfoModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
-      builder: (context, snapshot) {
-        String eventName = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.eventNameTopic)) ??
-            '';
-        int controlData = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.controlDataTopic)) ??
-            32;
-        bool redAlliance = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.allianceTopic)) ??
-            true;
-        int matchNumber = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.matchNumberTopic)) ??
-            0;
-        int matchType = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.matchTypeTopic)) ??
-            0;
-        int replayNumber = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.replayNumberTopic)) ??
-            0;
+    return ListenableBuilder(
+      listenable: Listenable.merge(model.subscriptions),
+      builder: (context, child) {
+        String eventName = tryCast(model.eventNameSubscription.value) ?? '';
+        int controlData = tryCast(model.controlDataSubscription.value) ?? 32;
+        bool redAlliance = tryCast(model.allianceSubscription.value) ?? true;
+        int matchNumber = tryCast(model.matchNumberSubscription.value) ?? 0;
+        int matchType = tryCast(model.matchTypeSubscription.value) ?? 0;
+        int replayNumber = tryCast(model.replayNumberSubscription.value) ?? 0;
 
         String eventNameDisplay = '$eventName${(eventName != '') ? ' ' : ''}';
         String matchTypeString = _getMatchTypeString(matchType);

--- a/lib/widgets/nt_widgets/multi-topic/gyro.dart
+++ b/lib/widgets/nt_widgets/multi-topic/gyro.dart
@@ -8,7 +8,7 @@ import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class GyroModel extends NTWidgetModel {
+class GyroModel extends SingleTopicNTWidgetModel {
   @override
   String type = Gyro.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/gyro.dart
+++ b/lib/widgets/nt_widgets/multi-topic/gyro.dart
@@ -8,13 +8,16 @@ import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class GyroModel extends SingleTopicNTWidgetModel {
+class GyroModel extends MultiTopicNTWidgetModel {
   @override
   String type = Gyro.widgetType;
 
   String get valueTopic => '$topic/Value';
 
   late NT4Subscription valueSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [valueSubscription];
 
   bool _counterClockwisePositive = false;
 
@@ -45,26 +48,8 @@ class GyroModel extends SingleTopicNTWidgetModel {
   }
 
   @override
-  void init() {
-    super.init();
-
+  void initializeSubscriptions() {
     valueSubscription = ntConnection.subscribe(valueTopic, super.period);
-  }
-
-  @override
-  void resetSubscription() {
-    ntConnection.unSubscribe(valueSubscription);
-
-    valueSubscription = ntConnection.subscribe(valueTopic, super.period);
-
-    super.resetSubscription();
-  }
-
-  @override
-  void unSubscribe() {
-    ntConnection.unSubscribe(valueSubscription);
-
-    super.unSubscribe();
   }
 
   @override
@@ -108,11 +93,10 @@ class Gyro extends NTWidget {
   Widget build(BuildContext context) {
     GyroModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.valueSubscription.periodicStream(yieldAll: false),
-      initialData: model.ntConnection.getLastAnnouncedValue(model.valueTopic),
-      builder: (context, snapshot) {
-        double value = tryCast(snapshot.data) ?? 0.0;
+    return ValueListenableBuilder(
+      valueListenable: model.valueSubscription,
+      builder: (context, data, child) {
+        double value = tryCast(data) ?? 0.0;
 
         if (model.counterClockwisePositive) {
           value *= -1;

--- a/lib/widgets/nt_widgets/multi-topic/motor_controller.dart
+++ b/lib/widgets/nt_widgets/multi-topic/motor_controller.dart
@@ -7,7 +7,7 @@ import 'package:syncfusion_flutter_gauges/gauges.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class MotorControllerModel extends NTWidgetModel {
+class MotorControllerModel extends SingleTopicNTWidgetModel {
   @override
   String type = MotorController.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/network_alerts.dart
+++ b/lib/widgets/nt_widgets/multi-topic/network_alerts.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class NetworkAlertsModel extends NTWidgetModel {
+class NetworkAlertsModel extends SingleTopicNTWidgetModel {
   @override
   String type = NetworkAlerts.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/network_alerts.dart
+++ b/lib/widgets/nt_widgets/multi-topic/network_alerts.dart
@@ -3,15 +3,27 @@ import 'package:flutter/material.dart';
 import 'package:dot_cast/dot_cast.dart';
 import 'package:provider/provider.dart';
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class NetworkAlertsModel extends SingleTopicNTWidgetModel {
+class NetworkAlertsModel extends MultiTopicNTWidgetModel {
   @override
   String type = NetworkAlerts.widgetType;
 
   String get errorsTopicName => '$topic/errors';
   String get warningsTopicName => '$topic/warnings';
   String get infosTopicName => '$topic/infos';
+
+  late NT4Subscription errorsSubscription;
+  late NT4Subscription warningsSubscription;
+  late NT4Subscription infosSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        errorsSubscription,
+        warningsSubscription,
+        infosSubscription,
+      ];
 
   NetworkAlertsModel({
     required super.ntConnection,
@@ -28,27 +40,11 @@ class NetworkAlertsModel extends SingleTopicNTWidgetModel {
   }) : super.fromJson();
 
   @override
-  List<Object> getCurrentData() {
-    List<Object?> errorsRaw = ntConnection
-            .getLastAnnouncedValue(errorsTopicName)
-            ?.tryCast<List<Object?>>() ??
-        [];
-
-    List<Object?> warningsRaw = ntConnection
-            .getLastAnnouncedValue(warningsTopicName)
-            ?.tryCast<List<Object?>>() ??
-        [];
-
-    List<Object?> infosRaw = ntConnection
-            .getLastAnnouncedValue(infosTopicName)
-            ?.tryCast<List<Object?>>() ??
-        [];
-
-    List<String> errors = errorsRaw.whereType<String>().toList();
-    List<String> warnings = warningsRaw.whereType<String>().toList();
-    List<String> infos = infosRaw.whereType<String>().toList();
-
-    return [...errors, ...warnings, ...infos];
+  void initializeSubscriptions() {
+    errorsSubscription = ntConnection.subscribe(errorsTopicName, super.period);
+    warningsSubscription =
+        ntConnection.subscribe(warningsTopicName, super.period);
+    infosSubscription = ntConnection.subscribe(infosTopicName, super.period);
   }
 }
 
@@ -61,23 +57,17 @@ class NetworkAlerts extends NTWidget {
   Widget build(BuildContext context) {
     NetworkAlertsModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
-      builder: (context, snapshot) {
-        List<Object?> errorsRaw = model.ntConnection
-                .getLastAnnouncedValue(model.errorsTopicName)
-                ?.tryCast<List<Object?>>() ??
-            [];
+    return ListenableBuilder(
+      listenable: Listenable.merge(model.subscriptions),
+      builder: (context, child) {
+        List<Object?> errorsRaw =
+            model.errorsSubscription.value?.tryCast<List<Object?>>() ?? [];
 
-        List<Object?> warningsRaw = model.ntConnection
-                .getLastAnnouncedValue(model.warningsTopicName)
-                ?.tryCast<List<Object?>>() ??
-            [];
+        List<Object?> warningsRaw =
+            model.warningsSubscription.value?.tryCast<List<Object?>>() ?? [];
 
-        List<Object?> infosRaw = model.ntConnection
-                .getLastAnnouncedValue(model.infosTopicName)
-                ?.tryCast<List<Object?>>() ??
-            [];
+        List<Object?> infosRaw =
+            model.infosSubscription.value?.tryCast<List<Object?>>() ?? [];
 
         List<String> errors = errorsRaw.whereType<String>().toList();
         List<String> warnings = warningsRaw.whereType<String>().toList();

--- a/lib/widgets/nt_widgets/multi-topic/pid_controller.dart
+++ b/lib/widgets/nt_widgets/multi-topic/pid_controller.dart
@@ -8,7 +8,7 @@ import 'package:elastic_dashboard/services/text_formatter_builder.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class PIDControllerModel extends NTWidgetModel {
+class PIDControllerModel extends SingleTopicNTWidgetModel {
   @override
   String type = PIDControllerWidget.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/pid_controller.dart
+++ b/lib/widgets/nt_widgets/multi-topic/pid_controller.dart
@@ -5,10 +5,9 @@ import 'package:provider/provider.dart';
 
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/services/text_formatter_builder.dart';
-import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class PIDControllerModel extends SingleTopicNTWidgetModel {
+class PIDControllerModel extends MultiTopicNTWidgetModel {
   @override
   String type = PIDControllerWidget.widgetType;
 
@@ -21,6 +20,19 @@ class PIDControllerModel extends SingleTopicNTWidgetModel {
   NT4Topic? _kiTopic;
   NT4Topic? _kdTopic;
   NT4Topic? _setpointTopic;
+
+  late NT4Subscription kpSubscription;
+  late NT4Subscription kiSubscription;
+  late NT4Subscription kdSubscription;
+  late NT4Subscription setpointSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        kpSubscription,
+        kiSubscription,
+        kdSubscription,
+        setpointSubscription,
+      ];
 
   TextEditingController? kpTextController;
   TextEditingController? kiTextController;
@@ -61,6 +73,15 @@ class PIDControllerModel extends SingleTopicNTWidgetModel {
     required super.preferences,
     required super.jsonData,
   }) : super.fromJson();
+
+  @override
+  void initializeSubscriptions() {
+    kpSubscription = ntConnection.subscribe(kpTopicName, super.period);
+    kiSubscription = ntConnection.subscribe(kiTopicName, super.period);
+    kdSubscription = ntConnection.subscribe(kdTopicName, super.period);
+    setpointSubscription =
+        ntConnection.subscribe(setpointTopicName, super.period);
+  }
 
   @override
   void resetSubscription() {
@@ -143,30 +164,6 @@ class PIDControllerModel extends SingleTopicNTWidgetModel {
 
     ntConnection.updateDataFromTopic(_setpointTopic!, data);
   }
-
-  @override
-  List<Object> getCurrentData() {
-    double kP = tryCast(ntConnection.getLastAnnouncedValue(kpTopicName)) ?? 0.0;
-    double kI = tryCast(ntConnection.getLastAnnouncedValue(kiTopicName)) ?? 0.0;
-    double kD = tryCast(ntConnection.getLastAnnouncedValue(kdTopicName)) ?? 0.0;
-    double setpoint =
-        tryCast(ntConnection.getLastAnnouncedValue(setpointTopicName)) ?? 0.0;
-
-    return [
-      kP,
-      kI,
-      kD,
-      setpoint,
-      _kpLastValue,
-      _kiLastValue,
-      _kdLastValue,
-      _setpointLastValue,
-      kpTextController?.text ?? '',
-      kiTextController?.text ?? '',
-      kdTextController?.text ?? '',
-      setpointTextController?.text ?? '',
-    ];
-  }
 }
 
 class PIDControllerWidget extends NTWidget {
@@ -178,28 +175,36 @@ class PIDControllerWidget extends NTWidget {
   Widget build(BuildContext context) {
     PIDControllerModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-        stream: model.multiTopicPeriodicStream,
-        builder: (context, snapshot) {
-          double kP = tryCast(model.ntConnection
-                  .getLastAnnouncedValue(model.kpTopicName)) ??
-              0.0;
-          double kI = tryCast(model.ntConnection
-                  .getLastAnnouncedValue(model.kiTopicName)) ??
-              0.0;
-          double kD = tryCast(model.ntConnection
-                  .getLastAnnouncedValue(model.kdTopicName)) ??
-              0.0;
-          double setpoint = tryCast(model.ntConnection
-                  .getLastAnnouncedValue(model.setpointTopicName)) ??
-              0.0;
+    return ListenableBuilder(
+        listenable: Listenable.merge([
+          ...model.subscriptions,
+          model.kpTextController,
+          model.kiTextController,
+          model.kdTextController,
+          model.setpointTextController,
+        ]),
+        builder: (context, child) {
+          double kP = tryCast(model.kpSubscription.value) ?? 0.0;
+          double kI = tryCast(model.kiSubscription.value) ?? 0.0;
+          double kD = tryCast(model.kdSubscription.value) ?? 0.0;
+          double setpoint = tryCast(model.setpointSubscription.value) ?? 0.0;
 
           // Creates the text editing controllers if they are null
+          bool wasNull = model.kpTextController == null ||
+              model.kiTextController == null ||
+              model.kdTextController == null ||
+              model.setpointTextController == null;
+
           model.kpTextController ??= TextEditingController(text: kP.toString());
           model.kiTextController ??= TextEditingController(text: kI.toString());
           model.kdTextController ??= TextEditingController(text: kD.toString());
           model.setpointTextController ??=
               TextEditingController(text: setpoint.toString());
+
+          // Since they were null they're not being listened to when created during build
+          if (wasNull) {
+            model.refresh();
+          }
 
           // Updates the text of the text editing controller if the kp value has changed
           if (kP != model.kpLastValue) {
@@ -236,6 +241,8 @@ class PIDControllerWidget extends NTWidget {
               kD != double.tryParse(model.kdTextController!.text) ||
               setpoint != double.tryParse(model.setpointTextController!.text);
 
+          // The text fields can't be DialogTextInput since DialogTextInput
+          // manages its own state which causes setState() while build errors
           return Column(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: [
@@ -248,12 +255,19 @@ class PIDControllerWidget extends NTWidget {
                   const Spacer(),
                   Flexible(
                     flex: 5,
-                    child: DialogTextInput(
-                      textEditingController: model.kpTextController,
-                      initialText: model.kpTextController!.text,
-                      label: 'kP',
-                      formatter: TextFormatterBuilder.decimalTextFormatter(),
-                      onSubmit: (value) {},
+                    child: TextField(
+                      controller: model.kpTextController,
+                      textAlign: TextAlign.left,
+                      inputFormatters: [
+                        TextFormatterBuilder.decimalTextFormatter()
+                      ],
+                      decoration: InputDecoration(
+                        contentPadding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                        labelText: 'kP',
+                        border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(4)),
+                      ),
+                      onSubmitted: (value) {},
                     ),
                   ),
                   const Spacer(),
@@ -268,12 +282,19 @@ class PIDControllerWidget extends NTWidget {
                   const Spacer(),
                   Flexible(
                     flex: 5,
-                    child: DialogTextInput(
-                      textEditingController: model.kiTextController,
-                      initialText: model.kiTextController!.text,
-                      label: 'kI',
-                      formatter: TextFormatterBuilder.decimalTextFormatter(),
-                      onSubmit: (value) {},
+                    child: TextField(
+                      controller: model.kiTextController,
+                      textAlign: TextAlign.left,
+                      inputFormatters: [
+                        TextFormatterBuilder.decimalTextFormatter()
+                      ],
+                      decoration: InputDecoration(
+                        contentPadding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                        labelText: 'kI',
+                        border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(4)),
+                      ),
+                      onSubmitted: (value) {},
                     ),
                   ),
                   const Spacer(),
@@ -288,12 +309,19 @@ class PIDControllerWidget extends NTWidget {
                   const Spacer(),
                   Flexible(
                     flex: 5,
-                    child: DialogTextInput(
-                      textEditingController: model.kdTextController,
-                      initialText: model.kdTextController!.text,
-                      label: 'kD',
-                      formatter: TextFormatterBuilder.decimalTextFormatter(),
-                      onSubmit: (value) {},
+                    child: TextField(
+                      controller: model.kdTextController,
+                      textAlign: TextAlign.left,
+                      inputFormatters: [
+                        TextFormatterBuilder.decimalTextFormatter()
+                      ],
+                      decoration: InputDecoration(
+                        contentPadding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                        labelText: 'kD',
+                        border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(4)),
+                      ),
+                      onSubmitted: (value) {},
                     ),
                   ),
                   const Spacer(),
@@ -306,13 +334,19 @@ class PIDControllerWidget extends NTWidget {
                   const Spacer(),
                   Flexible(
                     flex: 5,
-                    child: DialogTextInput(
-                      textEditingController: model.setpointTextController,
-                      initialText: model.setpointTextController!.text,
-                      label: 'Setpoint',
-                      formatter: TextFormatterBuilder.decimalTextFormatter(
-                          allowNegative: true),
-                      onSubmit: (value) {},
+                    child: TextField(
+                      controller: model.setpointTextController,
+                      textAlign: TextAlign.left,
+                      inputFormatters: [
+                        TextFormatterBuilder.decimalTextFormatter()
+                      ],
+                      decoration: InputDecoration(
+                        contentPadding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                        labelText: 'Setpoint',
+                        border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(4)),
+                      ),
+                      onSubmitted: (value) {},
                     ),
                   ),
                   const Spacer(),

--- a/lib/widgets/nt_widgets/multi-topic/power_distribution.dart
+++ b/lib/widgets/nt_widgets/multi-topic/power_distribution.dart
@@ -3,9 +3,10 @@ import 'package:flutter/material.dart';
 import 'package:dot_cast/dot_cast.dart';
 import 'package:provider/provider.dart';
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class PowerDistributionModel extends SingleTopicNTWidgetModel {
+class PowerDistributionModel extends MultiTopicNTWidgetModel {
   @override
   String type = PowerDistribution.widgetType;
 
@@ -15,6 +16,18 @@ class PowerDistributionModel extends SingleTopicNTWidgetModel {
 
   String get voltageTopic => '$topic/Voltage';
   String get currentTopic => '$topic/TotalCurrent';
+
+  late NT4Subscription voltageSubscription;
+  late NT4Subscription currentSubscription;
+
+  final List<NT4Subscription> channelSubscriptions = [];
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        voltageSubscription,
+        currentSubscription,
+        ...channelSubscriptions,
+      ];
 
   PowerDistributionModel({
     required super.ntConnection,
@@ -31,41 +44,20 @@ class PowerDistributionModel extends SingleTopicNTWidgetModel {
   }) : super.fromJson();
 
   @override
-  void init() {
-    super.init();
+  void initializeSubscriptions() {
+    voltageSubscription = ntConnection.subscribe(voltageTopic, super.period);
+    currentSubscription = ntConnection.subscribe(currentTopic, super.period);
 
-    for (int channel = 0; channel <= numberOfChannels; channel++) {
-      channelTopics.add('$topic/Chan$channel');
-    }
-  }
-
-  @override
-  void resetSubscription() {
     channelTopics.clear();
+    channelSubscriptions.clear();
 
     for (int channel = 0; channel <= numberOfChannels; channel++) {
       channelTopics.add('$topic/Chan$channel');
     }
 
-    super.resetSubscription();
-  }
-
-  @override
-  List<Object> getCurrentData() {
-    List<Object> data = [];
-
-    double voltage =
-        tryCast(ntConnection.getLastAnnouncedValue(voltageTopic)) ?? 0.0;
-    double totalCurrent =
-        tryCast(ntConnection.getLastAnnouncedValue(currentTopic)) ?? 0.0;
-
-    data.addAll([voltage, totalCurrent]);
-
-    for (String channel in channelTopics) {
-      data.add(tryCast(ntConnection.getLastAnnouncedValue(channel)) ?? 0.0);
+    for (String topic in channelTopics) {
+      channelSubscriptions.add(ntConnection.subscribe(topic, super.period));
     }
-
-    return data;
   }
 }
 
@@ -79,24 +71,27 @@ class PowerDistribution extends NTWidget {
     List<Widget> channels = [];
 
     for (int channel = start; channel <= end; channel++) {
-      double current = tryCast(model.ntConnection
-              .getLastAnnouncedValue(model.channelTopics[channel])) ??
-          0.0;
-
       channels.add(
         Row(
           mainAxisSize: MainAxisSize.max,
           children: [
-            Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surface,
-                borderRadius: BorderRadius.circular(10.0),
-              ),
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 24.0, vertical: 4.0),
-              child: Text('${current.toStringAsFixed(2).padLeft(5, '0')} A',
-                  style: TextStyle(
-                      color: Theme.of(context).colorScheme.onSurface)),
+            ValueListenableBuilder(
+              valueListenable: model.channelSubscriptions[channel],
+              builder: (context, value, child) {
+                double current = tryCast(value) ?? 0.0;
+
+                return Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.surface,
+                    borderRadius: BorderRadius.circular(10.0),
+                  ),
+                  padding: const EdgeInsets.symmetric(
+                      horizontal: 24.0, vertical: 4.0),
+                  child: Text('${current.toStringAsFixed(2).padLeft(5, '0')} A',
+                      style: TextStyle(
+                          color: Theme.of(context).colorScheme.onSurface)),
+                );
+              },
             ),
             const SizedBox(width: 10),
             Text('Ch. ${channel.toString().padRight(2)}'),
@@ -117,10 +112,6 @@ class PowerDistribution extends NTWidget {
     List<Widget> channels = [];
 
     for (int channel = start; channel >= end; channel--) {
-      double current = tryCast(model.ntConnection
-              .getLastAnnouncedValue(model.channelTopics[channel])) ??
-          0.0;
-
       channels.add(
         Row(
           mainAxisSize: MainAxisSize.max,
@@ -128,17 +119,23 @@ class PowerDistribution extends NTWidget {
           children: [
             Text('Ch. $channel'),
             const SizedBox(width: 10),
-            Container(
-              decoration: BoxDecoration(
-                color: Theme.of(context).colorScheme.surface,
-                borderRadius: BorderRadius.circular(10.0),
-              ),
-              padding:
-                  const EdgeInsets.symmetric(horizontal: 24.0, vertical: 4.0),
-              child: Text('${current.toStringAsFixed(2).padLeft(5, '0')} A',
-                  style: TextStyle(
-                      color: Theme.of(context).colorScheme.onSurface)),
-            ),
+            ValueListenableBuilder(
+                valueListenable: model.channelSubscriptions[channel],
+                builder: (context, value, child) {
+                  double current = tryCast(value) ?? 0.0;
+                  return Container(
+                    decoration: BoxDecoration(
+                      color: Theme.of(context).colorScheme.surface,
+                      borderRadius: BorderRadius.circular(10.0),
+                    ),
+                    padding: const EdgeInsets.symmetric(
+                        horizontal: 24.0, vertical: 4.0),
+                    child: Text(
+                        '${current.toStringAsFixed(2).padLeft(5, '0')} A',
+                        style: TextStyle(
+                            color: Theme.of(context).colorScheme.onSurface)),
+                  );
+                }),
           ],
         ),
       );
@@ -155,80 +152,80 @@ class PowerDistribution extends NTWidget {
   Widget build(BuildContext context) {
     PowerDistributionModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
-      builder: (context, snapshot) {
-        double voltage = tryCast(
-                model.ntConnection.getLastAnnouncedValue(model.voltageTopic)) ??
-            0.0;
-        double totalCurrent = tryCast(
-                model.ntConnection.getLastAnnouncedValue(model.currentTopic)) ??
-            0.0;
-
-        return Column(
+    return Column(
+      children: [
+        Row(
+          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
           children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+            // Voltage
+            Column(
               children: [
-                // Voltage
-                Column(
-                  children: [
-                    const Text('Voltage'),
-                    const SizedBox(height: 2.5),
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 48.0, vertical: 4.0),
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surface,
-                        borderRadius: BorderRadius.circular(10.0),
-                      ),
-                      child: Text(
-                        '${voltage.toStringAsFixed(2).padLeft(5, '0')} V',
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.onSurface,
+                const Text('Voltage'),
+                const SizedBox(height: 2.5),
+                ValueListenableBuilder(
+                    valueListenable: model.voltageSubscription,
+                    builder: (context, value, child) {
+                      double voltage = tryCast(value) ?? 0.0;
+
+                      return Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 48.0, vertical: 4.0),
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.surface,
+                          borderRadius: BorderRadius.circular(10.0),
                         ),
-                      ),
-                    ),
-                  ],
-                ),
-                // Current
-                Column(
-                  children: [
-                    const Text('Total Current'),
-                    const SizedBox(height: 2.5),
-                    Container(
-                      padding: const EdgeInsets.symmetric(
-                          horizontal: 48.0, vertical: 4.0),
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surface,
-                        borderRadius: BorderRadius.circular(10.0),
-                      ),
-                      child: Text(
-                        '${totalCurrent.toStringAsFixed(2).padLeft(5, '0')} A',
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.onSurface,
+                        child: Text(
+                          '${voltage.toStringAsFixed(2).padLeft(5, '0')} V',
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.onSurface,
+                          ),
                         ),
-                      ),
-                    ),
-                  ],
-                ),
+                      );
+                    }),
               ],
             ),
-            const SizedBox(height: 5),
-            // Channel current
-            Expanded(
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                children: [
-                  // First 12 channels
-                  _getChannelsColumn(model, context, 0, 11),
-                  _getReversedChannelsColumn(model, context, 23, 12),
-                ],
-              ),
+            // Current
+            Column(
+              children: [
+                const Text('Total Current'),
+                const SizedBox(height: 2.5),
+                ValueListenableBuilder(
+                    valueListenable: model.currentSubscription,
+                    builder: (context, value, child) {
+                      double totalCurrent = tryCast(value) ?? 0.0;
+
+                      return Container(
+                        padding: const EdgeInsets.symmetric(
+                            horizontal: 48.0, vertical: 4.0),
+                        decoration: BoxDecoration(
+                          color: Theme.of(context).colorScheme.surface,
+                          borderRadius: BorderRadius.circular(10.0),
+                        ),
+                        child: Text(
+                          '${totalCurrent.toStringAsFixed(2).padLeft(5, '0')} A',
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.onSurface,
+                          ),
+                        ),
+                      );
+                    }),
+              ],
             ),
           ],
-        );
-      },
+        ),
+        const SizedBox(height: 5),
+        // Channel current
+        Expanded(
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              // First 12 channels
+              _getChannelsColumn(model, context, 0, 11),
+              _getReversedChannelsColumn(model, context, 23, 12),
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/widgets/nt_widgets/multi-topic/power_distribution.dart
+++ b/lib/widgets/nt_widgets/multi-topic/power_distribution.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class PowerDistributionModel extends NTWidgetModel {
+class PowerDistributionModel extends SingleTopicNTWidgetModel {
   @override
   String type = PowerDistribution.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/profiled_pid_controller.dart
+++ b/lib/widgets/nt_widgets/multi-topic/profiled_pid_controller.dart
@@ -8,7 +8,7 @@ import 'package:elastic_dashboard/services/text_formatter_builder.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class ProfiledPIDControllerModel extends NTWidgetModel {
+class ProfiledPIDControllerModel extends SingleTopicNTWidgetModel {
   @override
   String type = ProfiledPIDControllerWidget.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/profiled_pid_controller.dart
+++ b/lib/widgets/nt_widgets/multi-topic/profiled_pid_controller.dart
@@ -5,10 +5,9 @@ import 'package:provider/provider.dart';
 
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/services/text_formatter_builder.dart';
-import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class ProfiledPIDControllerModel extends SingleTopicNTWidgetModel {
+class ProfiledPIDControllerModel extends MultiTopicNTWidgetModel {
   @override
   String type = ProfiledPIDControllerWidget.widgetType;
 
@@ -21,6 +20,19 @@ class ProfiledPIDControllerModel extends SingleTopicNTWidgetModel {
   NT4Topic? _kiTopic;
   NT4Topic? _kdTopic;
   NT4Topic? _goalTopic;
+
+  late NT4Subscription kpSubscription;
+  late NT4Subscription kiSubscription;
+  late NT4Subscription kdSubscription;
+  late NT4Subscription goalSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        kpSubscription,
+        kiSubscription,
+        kdSubscription,
+        goalSubscription,
+      ];
 
   TextEditingController? kpTextController;
   TextEditingController? kiTextController;
@@ -61,6 +73,14 @@ class ProfiledPIDControllerModel extends SingleTopicNTWidgetModel {
     required super.preferences,
     required super.jsonData,
   }) : super.fromJson();
+
+  @override
+  void initializeSubscriptions() {
+    kpSubscription = ntConnection.subscribe(kpTopicName, super.period);
+    kiSubscription = ntConnection.subscribe(kiTopicName, super.period);
+    kdSubscription = ntConnection.subscribe(kdTopicName, super.period);
+    goalSubscription = ntConnection.subscribe(goalTopicName, super.period);
+  }
 
   @override
   void resetSubscription() {
@@ -143,30 +163,6 @@ class ProfiledPIDControllerModel extends SingleTopicNTWidgetModel {
 
     ntConnection.updateDataFromTopic(_goalTopic!, data);
   }
-
-  @override
-  List<Object> getCurrentData() {
-    double kP = tryCast(ntConnection.getLastAnnouncedValue(kpTopicName)) ?? 0.0;
-    double kI = tryCast(ntConnection.getLastAnnouncedValue(kiTopicName)) ?? 0.0;
-    double kD = tryCast(ntConnection.getLastAnnouncedValue(kdTopicName)) ?? 0.0;
-    double goal =
-        tryCast(ntConnection.getLastAnnouncedValue(goalTopicName)) ?? 0.0;
-
-    return [
-      kP,
-      kI,
-      kD,
-      goal,
-      _kpLastValue,
-      _kiLastValue,
-      _kdLastValue,
-      _goalLastValue,
-      kpTextController?.text ?? '',
-      kiTextController?.text ?? '',
-      kdTextController?.text ?? '',
-      goalTextController?.text ?? '',
-    ];
-  }
 }
 
 class ProfiledPIDControllerWidget extends NTWidget {
@@ -178,28 +174,36 @@ class ProfiledPIDControllerWidget extends NTWidget {
   Widget build(BuildContext context) {
     ProfiledPIDControllerModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-        stream: model.multiTopicPeriodicStream,
-        builder: (context, snapshot) {
-          double kP = tryCast(model.ntConnection
-                  .getLastAnnouncedValue(model.kpTopicName)) ??
-              0.0;
-          double kI = tryCast(model.ntConnection
-                  .getLastAnnouncedValue(model.kiTopicName)) ??
-              0.0;
-          double kD = tryCast(model.ntConnection
-                  .getLastAnnouncedValue(model.kdTopicName)) ??
-              0.0;
-          double goal = tryCast(model.ntConnection
-                  .getLastAnnouncedValue(model.goalTopicName)) ??
-              0.0;
+    return ListenableBuilder(
+        listenable: Listenable.merge([
+          ...model.subscriptions,
+          model.kpTextController,
+          model.kiTextController,
+          model.kdTextController,
+          model.goalTextController,
+        ]),
+        builder: (context, child) {
+          double kP = tryCast(model.kpSubscription.value) ?? 0.0;
+          double kI = tryCast(model.kiSubscription.value) ?? 0.0;
+          double kD = tryCast(model.kdSubscription.value) ?? 0.0;
+          double goal = tryCast(model.goalSubscription.value) ?? 0.0;
 
           // Creates the text editing controllers if they are null
+          bool wasNull = model.kpTextController == null ||
+              model.kiTextController == null ||
+              model.kdTextController == null ||
+              model.goalTextController == null;
+
           model.kpTextController ??= TextEditingController(text: kP.toString());
           model.kiTextController ??= TextEditingController(text: kI.toString());
           model.kdTextController ??= TextEditingController(text: kD.toString());
           model.goalTextController ??=
               TextEditingController(text: goal.toString());
+
+          // Since they were null they're not being listened to when created during build
+          if (wasNull) {
+            model.refresh();
+          }
 
           // Updates the text of the text editing controller if the kp value has changed
           if (kP != model.kpLastValue) {
@@ -236,6 +240,8 @@ class ProfiledPIDControllerWidget extends NTWidget {
                   kD != double.tryParse(model.kdTextController!.text) ||
                   goal != double.tryParse(model.goalTextController!.text);
 
+          // The text fields can't be DialogTextInput since DialogTextInput
+          // manages its own state which causes setState() while build errors
           return Column(
             mainAxisAlignment: MainAxisAlignment.spaceEvenly,
             children: [
@@ -248,12 +254,19 @@ class ProfiledPIDControllerWidget extends NTWidget {
                   const Spacer(),
                   Flexible(
                     flex: 5,
-                    child: DialogTextInput(
-                      textEditingController: model.kpTextController,
-                      initialText: model.kpTextController!.text,
-                      label: 'kP',
-                      formatter: TextFormatterBuilder.decimalTextFormatter(),
-                      onSubmit: (value) {},
+                    child: TextField(
+                      controller: model.kpTextController,
+                      textAlign: TextAlign.left,
+                      inputFormatters: [
+                        TextFormatterBuilder.decimalTextFormatter()
+                      ],
+                      decoration: InputDecoration(
+                        contentPadding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                        labelText: 'kP',
+                        border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(4)),
+                      ),
+                      onSubmitted: (value) {},
                     ),
                   ),
                   const Spacer(),
@@ -268,12 +281,19 @@ class ProfiledPIDControllerWidget extends NTWidget {
                   const Spacer(),
                   Flexible(
                     flex: 5,
-                    child: DialogTextInput(
-                      textEditingController: model.kiTextController,
-                      initialText: model.kiTextController!.text,
-                      label: 'kI',
-                      formatter: TextFormatterBuilder.decimalTextFormatter(),
-                      onSubmit: (value) {},
+                    child: TextField(
+                      controller: model.kiTextController,
+                      textAlign: TextAlign.left,
+                      inputFormatters: [
+                        TextFormatterBuilder.decimalTextFormatter()
+                      ],
+                      decoration: InputDecoration(
+                        contentPadding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                        labelText: 'kI',
+                        border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(4)),
+                      ),
+                      onSubmitted: (value) {},
                     ),
                   ),
                   const Spacer(),
@@ -288,12 +308,19 @@ class ProfiledPIDControllerWidget extends NTWidget {
                   const Spacer(),
                   Flexible(
                     flex: 5,
-                    child: DialogTextInput(
-                      textEditingController: model.kdTextController,
-                      initialText: model.kdTextController!.text,
-                      label: 'kD',
-                      formatter: TextFormatterBuilder.decimalTextFormatter(),
-                      onSubmit: (value) {},
+                    child: TextField(
+                      controller: model.kdTextController,
+                      textAlign: TextAlign.left,
+                      inputFormatters: [
+                        TextFormatterBuilder.decimalTextFormatter()
+                      ],
+                      decoration: InputDecoration(
+                        contentPadding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                        labelText: 'kD',
+                        border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(4)),
+                      ),
+                      onSubmitted: (value) {},
                     ),
                   ),
                   const Spacer(),
@@ -306,13 +333,19 @@ class ProfiledPIDControllerWidget extends NTWidget {
                   const Spacer(),
                   Flexible(
                     flex: 5,
-                    child: DialogTextInput(
-                      textEditingController: model.goalTextController,
-                      initialText: model.goalTextController!.text,
-                      label: 'Goal',
-                      formatter: TextFormatterBuilder.decimalTextFormatter(
-                          allowNegative: true),
-                      onSubmit: (value) {},
+                    child: TextField(
+                      controller: model.goalTextController,
+                      textAlign: TextAlign.left,
+                      inputFormatters: [
+                        TextFormatterBuilder.decimalTextFormatter()
+                      ],
+                      decoration: InputDecoration(
+                        contentPadding: const EdgeInsets.fromLTRB(8, 4, 8, 4),
+                        labelText: 'Goal',
+                        border: OutlineInputBorder(
+                            borderRadius: BorderRadius.circular(4)),
+                      ),
+                      onSubmitted: (value) {},
                     ),
                   ),
                   const Spacer(),

--- a/lib/widgets/nt_widgets/multi-topic/relay_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/relay_widget.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class RelayModel extends NTWidgetModel {
+class RelayModel extends SingleTopicNTWidgetModel {
   @override
   String type = RelayWidget.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/relay_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/relay_widget.dart
@@ -6,13 +6,17 @@ import 'package:provider/provider.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class RelayModel extends SingleTopicNTWidgetModel {
+class RelayModel extends MultiTopicNTWidgetModel {
   @override
   String type = RelayWidget.widgetType;
 
   String get valueTopicName => '$topic/Value';
 
   late NT4Subscription valueSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [valueSubscription];
+
   NT4Topic? valueTopic;
 
   final List<String> selectedOptions = ['Off', 'On', 'Forward', 'Reverse'];
@@ -32,17 +36,12 @@ class RelayModel extends SingleTopicNTWidgetModel {
   }) : super.fromJson();
 
   @override
-  void init() {
-    super.init();
-
+  void initializeSubscriptions() {
     valueSubscription = ntConnection.subscribe(valueTopicName, super.period);
   }
 
   @override
   void resetSubscription() {
-    ntConnection.unSubscribe(valueSubscription);
-
-    valueSubscription = ntConnection.subscribe(valueTopicName, super.period);
     valueTopic = null;
 
     super.resetSubscription();
@@ -50,10 +49,9 @@ class RelayModel extends SingleTopicNTWidgetModel {
 
   @override
   void unSubscribe() {
-    super.unSubscribe();
-
-    ntConnection.unSubscribe(valueSubscription);
     valueTopic = null;
+
+    super.unSubscribe();
   }
 }
 
@@ -66,12 +64,10 @@ class RelayWidget extends NTWidget {
   Widget build(BuildContext context) {
     RelayModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.valueSubscription.periodicStream(yieldAll: false),
-      initialData:
-          model.ntConnection.getLastAnnouncedValue(model.valueTopicName),
-      builder: (context, snapshot) {
-        String selected = tryCast(snapshot.data) ?? 'Off';
+    return ValueListenableBuilder(
+      valueListenable: model.valueSubscription,
+      builder: (context, data, child) {
+        String selected = tryCast(data) ?? 'Off';
 
         if (!model.selectedOptions.contains(selected)) {
           selected = 'Off';

--- a/lib/widgets/nt_widgets/multi-topic/robot_preferences.dart
+++ b/lib/widgets/nt_widgets/multi-topic/robot_preferences.dart
@@ -7,16 +7,25 @@ import 'package:searchable_listview/searchable_listview.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class RobotPreferencesModel extends SingleTopicNTWidgetModel {
+class RobotPreferencesModel extends MultiTopicNTWidgetModel {
   @override
   String type = RobotPreferences.widgetType;
 
   final TextEditingController searchTextController = TextEditingController();
 
   final List<String> preferenceTopicNames = [];
+  final Map<String, NT4Subscription> preferenceSubscriptions = {};
   final Map<String, NT4Topic> preferenceTopics = {};
   final Map<String, TextEditingController> preferenceTextControllers = {};
   final Map<String, Object?> previousValues = {};
+
+  @override
+  List<NT4Subscription> get subscriptions =>
+      preferenceSubscriptions.values.toList();
+
+  late Function(NT4Topic topic) topicAnnounceListener;
+
+  late Function(NT4Topic topic) topicUnannounceListener;
 
   PreferenceSearch? searchWidget;
 
@@ -33,6 +42,70 @@ class RobotPreferencesModel extends SingleTopicNTWidgetModel {
     required super.preferences,
     required super.jsonData,
   }) : super.fromJson();
+
+  @override
+  void init() {
+    topicAnnounceListener = (topic) {
+      if (!topic.name.contains(this.topic) ||
+          preferenceTopicNames.contains(topic.name) ||
+          topic.name.contains('.type')) {
+        return;
+      }
+
+      Object? previousValue = ntConnection.getLastAnnouncedValue(topic.name);
+
+      preferenceTopicNames.add(topic.name);
+      preferenceTopics.addAll({topic.name: topic});
+      preferenceSubscriptions.addAll({
+        topic.name: ntConnection.subscribe(topic.name, super.period),
+      });
+      preferenceTextControllers.addAll({
+        topic.name: TextEditingController()
+          ..text = previousValue?.toString() ?? ''
+      });
+      previousValues.addAll({topic.name: previousValue});
+
+      notifyListeners();
+    };
+
+    topicUnannounceListener = (topic) {
+      if (!preferenceTopicNames.contains(topic.name)) {
+        return;
+      }
+
+      preferenceTopicNames.remove(topic.name);
+
+      preferenceTopics.remove(topic.name);
+
+      if (preferenceSubscriptions.containsKey(topic.name)) {
+        ntConnection.unSubscribe(preferenceSubscriptions[topic.name]!);
+      }
+      preferenceSubscriptions.remove(topic.name);
+
+      preferenceTextControllers.remove(topic.name);
+
+      previousValues.remove(topic.name);
+
+      notifyListeners();
+    };
+
+    ntConnection.addTopicAnnounceListener(topicAnnounceListener);
+    ntConnection.addTopicUnannounceListener(topicUnannounceListener);
+
+    super.init();
+  }
+
+  @override
+  void resetSubscription() {
+    for (NT4Subscription subscription in preferenceSubscriptions.values) {
+      ntConnection.unSubscribe(subscription);
+    }
+    preferenceSubscriptions.clear();
+
+    // Trigger the topics to get recalled to the listener and added to the preferences list
+    ntConnection.removeTopicAnnounceListener(topicAnnounceListener);
+    ntConnection.addTopicAnnounceListener(topicAnnounceListener);
+  }
 }
 
 class RobotPreferences extends NTWidget {
@@ -44,65 +117,21 @@ class RobotPreferences extends NTWidget {
   Widget build(BuildContext context) {
     RobotPreferencesModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.subscription?.periodicStream(),
-      builder: (context, snapshot) {
-        bool rebuildWidget = model.searchWidget == null;
+    return ListenableBuilder(
+        listenable: Listenable.merge(model.subscriptions),
+        builder: (context, child) {
+          for (String topic in model.preferenceTopicNames) {
+            if (model.preferenceSubscriptions[topic]?.value.toString() !=
+                model.previousValues[topic].toString()) {
+              model.preferenceTextControllers[topic]?.text =
+                  model.preferenceSubscriptions[topic]?.value?.toString() ?? '';
 
-        for (NT4Topic nt4Topic in model.ntConnection.announcedTopics().values) {
-          if (!nt4Topic.name.contains(model.topic) ||
-              model.preferenceTopicNames.contains(nt4Topic.name) ||
-              nt4Topic.name.contains('.type')) {
-            continue;
+              model.previousValues[topic] =
+                  model.preferenceSubscriptions[topic]?.value;
+            }
           }
 
-          Object? previousValue =
-              model.ntConnection.getLastAnnouncedValue(nt4Topic.name);
-
-          model.preferenceTopicNames.add(nt4Topic.name);
-          model.preferenceTopics.addAll({nt4Topic.name: nt4Topic});
-          model.preferenceTextControllers.addAll({
-            nt4Topic.name: TextEditingController()
-              ..text = previousValue?.toString() ?? ''
-          });
-          model.previousValues.addAll({nt4Topic.name: previousValue});
-
-          rebuildWidget = true;
-        }
-
-        Iterable<String> announcedTopics =
-            model.ntConnection.announcedTopics().values.map(
-                  (e) => e.name,
-                );
-
-        for (String topic in model.preferenceTopicNames) {
-          if (!announcedTopics.contains(topic)) {
-            model.preferenceTopics.remove(topic);
-
-            model.preferenceTextControllers.remove(topic);
-
-            model.previousValues.remove(topic);
-
-            rebuildWidget = true;
-
-            continue;
-          }
-
-          if (model.ntConnection.getLastAnnouncedValue(topic).toString() !=
-              model.previousValues[topic].toString()) {
-            model.preferenceTextControllers[topic]?.text =
-                model.ntConnection.getLastAnnouncedValue(topic).toString();
-
-            model.previousValues[topic] =
-                model.ntConnection.getLastAnnouncedValue(topic);
-          }
-        }
-
-        model.preferenceTopicNames
-            .removeWhere((element) => !announcedTopics.contains(element));
-
-        if (rebuildWidget) {
-          model.searchWidget = PreferenceSearch(
+          return PreferenceSearch(
             onSubmit: (String topic, String? data) {
               if (data == null) {
                 return;
@@ -148,34 +177,33 @@ class RobotPreferences extends NTWidget {
               model.preferenceTextControllers[topic]?.text =
                   formattedData.toString();
             },
-            searchTextController: model.searchTextController,
-            preferenceTopicNames: model.preferenceTopicNames,
-            preferenceTextControllers: model.preferenceTextControllers,
-            preferenceTopics: model.preferenceTopics,
+            model: model,
+            // searchTextController: model.searchTextController,
+            // preferenceTopicNames: model.preferenceTopicNames,
+            // preferenceTextControllers: model.preferenceTextControllers,
+            // preferenceTopics: model.preferenceTopics,
           );
-        }
-
-        return model.searchWidget!;
-      },
-    );
+        });
   }
 }
 
 class PreferenceSearch extends StatelessWidget {
   const PreferenceSearch({
     super.key,
+    required this.model,
     required this.onSubmit,
-    required this.searchTextController,
-    required this.preferenceTopicNames,
-    required this.preferenceTextControllers,
-    required this.preferenceTopics,
+    // required this.searchTextController,
+    // required this.preferenceTopicNames,
+    // required this.preferenceTextControllers,
+    // required this.preferenceTopics,
   });
 
+  final RobotPreferencesModel model;
   final Function(String topic, String? data) onSubmit;
-  final TextEditingController searchTextController;
-  final List<String> preferenceTopicNames;
-  final Map<String, TextEditingController> preferenceTextControllers;
-  final Map<String, NT4Topic> preferenceTopics;
+  // final TextEditingController searchTextController;
+  // final List<String> preferenceTopicNames;
+  // final Map<String, TextEditingController> preferenceTextControllers;
+  // final Map<String, NT4Topic> preferenceTopics;
 
   @override
   Widget build(BuildContext context) {
@@ -191,11 +219,11 @@ class PreferenceSearch extends StatelessWidget {
           borderRadius: BorderRadius.circular(8),
         ),
       ),
-      searchTextController: searchTextController,
+      searchTextController: model.searchTextController,
       seperatorBuilder: (context, _) => const Divider(height: 4.0),
       spaceBetweenSearchAndList: 15,
       filter: (query) {
-        return preferenceTopicNames
+        return model.preferenceTopicNames
             .where((element) => element
                 .split('/')
                 .last
@@ -203,9 +231,10 @@ class PreferenceSearch extends StatelessWidget {
                 .contains(query.toLowerCase()))
             .toList();
       },
-      initialList: preferenceTopicNames,
+      initialList: model.preferenceTopicNames,
       itemBuilder: (item) {
-        TextEditingController? textController = preferenceTextControllers[item];
+        TextEditingController? textController =
+            model.preferenceTextControllers[item];
 
         return _RobotPreference(
           label: item.split('/').last,

--- a/lib/widgets/nt_widgets/multi-topic/robot_preferences.dart
+++ b/lib/widgets/nt_widgets/multi-topic/robot_preferences.dart
@@ -7,7 +7,7 @@ import 'package:searchable_listview/searchable_listview.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class RobotPreferencesModel extends NTWidgetModel {
+class RobotPreferencesModel extends SingleTopicNTWidgetModel {
   @override
   String type = RobotPreferences.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/robot_preferences.dart
+++ b/lib/widgets/nt_widgets/multi-topic/robot_preferences.dart
@@ -133,13 +133,15 @@ class RobotPreferences extends NTWidget {
 
           return PreferenceSearch(
             onSubmit: (String topic, String? data) {
-              if (data == null) {
+              NT4Topic? nt4Topic = model.preferenceTopics[topic];
+
+              if (nt4Topic == null ||
+                  !model.ntConnection.isTopicPublished(nt4Topic)) {
                 return;
               }
 
-              NT4Topic? nt4Topic = model.preferenceTopics[topic];
-
-              if (nt4Topic == null) {
+              if (data == null) {
+                model.ntConnection.unpublishTopic(nt4Topic);
                 return;
               }
 

--- a/lib/widgets/nt_widgets/multi-topic/split_button_chooser.dart
+++ b/lib/widgets/nt_widgets/multi-topic/split_button_chooser.dart
@@ -7,7 +7,7 @@ import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/multi-topic/combo_box_chooser.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class SplitButtonChooserModel extends SingleTopicNTWidgetModel {
+class SplitButtonChooserModel extends MultiTopicNTWidgetModel {
   @override
   String type = SplitButtonChooser.widgetType;
 
@@ -15,6 +15,19 @@ class SplitButtonChooserModel extends SingleTopicNTWidgetModel {
   String get selectedTopicName => '$topic/selected';
   String get activeTopicName => '$topic/active';
   String get defaultTopicName => '$topic/default';
+
+  late NT4Subscription optionsSubscription;
+  late NT4Subscription selectedSubscription;
+  late NT4Subscription activeSubscription;
+  late NT4Subscription defaultSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        optionsSubscription,
+        selectedSubscription,
+        activeSubscription,
+        defaultSubscription,
+      ];
 
   String? selectedChoice;
 
@@ -36,6 +49,17 @@ class SplitButtonChooserModel extends SingleTopicNTWidgetModel {
     required super.preferences,
     required super.jsonData,
   }) : super.fromJson();
+
+  @override
+  void initializeSubscriptions() {
+    optionsSubscription =
+        ntConnection.subscribe(optionsTopicName, super.period);
+    selectedSubscription =
+        ntConnection.subscribe(selectedTopicName, super.period);
+    activeSubscription = ntConnection.subscribe(activeTopicName, super.period);
+    defaultSubscription =
+        ntConnection.subscribe(defaultTopicName, super.period);
+  }
 
   @override
   void resetSubscription() {
@@ -74,27 +98,6 @@ class SplitButtonChooserModel extends SingleTopicNTWidgetModel {
 
     ntConnection.updateDataFromTopic(_activeTopic!, active);
   }
-
-  @override
-  List<Object> getCurrentData() {
-    List<Object?> rawOptions = ntConnection
-            .getLastAnnouncedValue(optionsTopicName)
-            ?.tryCast<List<Object?>>() ??
-        [];
-
-    List<String> options = rawOptions.whereType<String>().toList();
-
-    String active =
-        tryCast(ntConnection.getLastAnnouncedValue(activeTopicName)) ?? '';
-
-    String selected =
-        tryCast(ntConnection.getLastAnnouncedValue(selectedTopicName)) ?? '';
-
-    String defaultOption =
-        tryCast(ntConnection.getLastAnnouncedValue(defaultTopicName)) ?? '';
-
-    return [...options, active, selected, defaultOption];
-  }
 }
 
 class SplitButtonChooser extends NTWidget {
@@ -106,30 +109,25 @@ class SplitButtonChooser extends NTWidget {
   Widget build(BuildContext context) {
     SplitButtonChooserModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
-      builder: (context, snapshot) {
-        List<Object?> rawOptions = model.ntConnection
-                .getLastAnnouncedValue(model.optionsTopicName)
-                ?.tryCast<List<Object?>>() ??
-            [];
+    return ListenableBuilder(
+      listenable: Listenable.merge(model.subscriptions),
+      builder: (context, child) {
+        List<Object?> rawOptions =
+            model.optionsSubscription.value?.tryCast<List<Object?>>() ?? [];
 
         List<String> options = rawOptions.whereType<String>().toList();
 
-        String? active = tryCast(
-            model.ntConnection.getLastAnnouncedValue(model.activeTopicName));
+        String? active = tryCast(model.activeSubscription.value);
         if (active != null && active == '') {
           active = null;
         }
 
-        String? selected = tryCast(
-            model.ntConnection.getLastAnnouncedValue(model.selectedTopicName));
+        String? selected = tryCast(model.selectedSubscription.value);
         if (selected != null && selected == '') {
           selected = null;
         }
 
-        String? defaultOption = tryCast(
-            model.ntConnection.getLastAnnouncedValue(model.defaultTopicName));
+        String? defaultOption = tryCast(model.defaultSubscription.value);
         if (defaultOption != null && defaultOption == '') {
           defaultOption = null;
         }

--- a/lib/widgets/nt_widgets/multi-topic/split_button_chooser.dart
+++ b/lib/widgets/nt_widgets/multi-topic/split_button_chooser.dart
@@ -7,7 +7,7 @@ import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/multi-topic/combo_box_chooser.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class SplitButtonChooserModel extends NTWidgetModel {
+class SplitButtonChooserModel extends SingleTopicNTWidgetModel {
   @override
   String type = SplitButtonChooser.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/subsystem_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/subsystem_widget.dart
@@ -3,14 +3,24 @@ import 'package:flutter/material.dart';
 import 'package:dot_cast/dot_cast.dart';
 import 'package:provider/provider.dart';
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class SubsystemModel extends SingleTopicNTWidgetModel {
+class SubsystemModel extends MultiTopicNTWidgetModel {
   @override
   String type = SubsystemWidget.widgetType;
 
   String get defaultCommandTopic => '$topic/.default';
   String get currentCommandTopic => '$topic/.command';
+
+  late NT4Subscription defaultCommandSubscription;
+  late NT4Subscription currentCommandSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        defaultCommandSubscription,
+        currentCommandSubscription,
+      ];
 
   SubsystemModel({
     required super.ntConnection,
@@ -27,15 +37,11 @@ class SubsystemModel extends SingleTopicNTWidgetModel {
   }) : super.fromJson();
 
   @override
-  List<Object> getCurrentData() {
-    String defaultCommand =
-        tryCast(ntConnection.getLastAnnouncedValue(defaultCommandTopic)) ??
-            'none';
-    String currentCommand =
-        tryCast(ntConnection.getLastAnnouncedValue(currentCommandTopic)) ??
-            'none';
-
-    return [defaultCommand, currentCommand];
+  void initializeSubscriptions() {
+    defaultCommandSubscription =
+        ntConnection.subscribe(defaultCommandTopic, super.period);
+    currentCommandSubscription =
+        ntConnection.subscribe(currentCommandTopic, super.period);
   }
 }
 
@@ -48,27 +54,29 @@ class SubsystemWidget extends NTWidget {
   Widget build(BuildContext context) {
     SubsystemModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
-      builder: (context, snapshot) {
-        String defaultCommand = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.defaultCommandTopic)) ??
-            'none';
-        String currentCommand = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.currentCommandTopic)) ??
-            'none';
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.start,
+      children: [
+        ValueListenableBuilder(
+          valueListenable: model.defaultCommandSubscription,
+          builder: (context, value, child) {
+            String defaultCommand = tryCast(value) ?? 'none';
 
-        return Column(
-          mainAxisAlignment: MainAxisAlignment.start,
-          children: [
-            Text('Default Command: $defaultCommand',
-                overflow: TextOverflow.ellipsis),
-            const SizedBox(height: 5),
-            Text('Current Command: $currentCommand',
-                overflow: TextOverflow.ellipsis),
-          ],
-        );
-      },
+            return Text('Default Command: $defaultCommand',
+                overflow: TextOverflow.ellipsis);
+          },
+        ),
+        const SizedBox(height: 5),
+        ValueListenableBuilder(
+          valueListenable: model.currentCommandSubscription,
+          builder: (context, value, child) {
+            String currentCommand = tryCast(value) ?? 'none';
+
+            return Text('Current Command: $currentCommand',
+                overflow: TextOverflow.ellipsis);
+          },
+        ),
+      ],
     );
   }
 }

--- a/lib/widgets/nt_widgets/multi-topic/subsystem_widget.dart
+++ b/lib/widgets/nt_widgets/multi-topic/subsystem_widget.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class SubsystemModel extends NTWidgetModel {
+class SubsystemModel extends SingleTopicNTWidgetModel {
   @override
   String type = SubsystemWidget.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/three_axis_accelerometer.dart
+++ b/lib/widgets/nt_widgets/multi-topic/three_axis_accelerometer.dart
@@ -1,9 +1,9 @@
-import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:flutter/material.dart';
 
 import 'package:dot_cast/dot_cast.dart';
 import 'package:provider/provider.dart';
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
 class ThreeAxisAccelerometerModel extends MultiTopicNTWidgetModel {

--- a/lib/widgets/nt_widgets/multi-topic/three_axis_accelerometer.dart
+++ b/lib/widgets/nt_widgets/multi-topic/three_axis_accelerometer.dart
@@ -1,3 +1,4 @@
+import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:flutter/material.dart';
 
 import 'package:dot_cast/dot_cast.dart';
@@ -5,13 +6,24 @@ import 'package:provider/provider.dart';
 
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class ThreeAxisAccelerometerModel extends SingleTopicNTWidgetModel {
+class ThreeAxisAccelerometerModel extends MultiTopicNTWidgetModel {
   @override
   String type = ThreeAxisAccelerometer.widgetType;
 
   String get xTopic => '$topic/X';
   String get yTopic => '$topic/Y';
   String get zTopic => '$topic/Z';
+
+  late NT4Subscription xSubscription;
+  late NT4Subscription ySubscription;
+  late NT4Subscription zSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        xSubscription,
+        ySubscription,
+        zSubscription,
+      ];
 
   ThreeAxisAccelerometerModel({
     required super.ntConnection,
@@ -28,12 +40,10 @@ class ThreeAxisAccelerometerModel extends SingleTopicNTWidgetModel {
   }) : super.fromJson();
 
   @override
-  List<Object> getCurrentData() {
-    double xAccel = tryCast(ntConnection.getLastAnnouncedValue(xTopic)) ?? 0.0;
-    double yAccel = tryCast(ntConnection.getLastAnnouncedValue(yTopic)) ?? 0.0;
-    double zAccel = tryCast(ntConnection.getLastAnnouncedValue(zTopic)) ?? 0.0;
-
-    return [xAccel, yAccel, zAccel];
+  void initializeSubscriptions() {
+    xSubscription = ntConnection.subscribe(xTopic, super.period);
+    ySubscription = ntConnection.subscribe(yTopic, super.period);
+    zSubscription = ntConnection.subscribe(zTopic, super.period);
   }
 }
 
@@ -46,122 +56,122 @@ class ThreeAxisAccelerometer extends NTWidget {
   Widget build(BuildContext context) {
     ThreeAxisAccelerometerModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
-      builder: (context, snapshot) {
-        double xAccel =
-            tryCast(model.ntConnection.getLastAnnouncedValue(model.xTopic)) ??
-                0.0;
-        double yAccel =
-            tryCast(model.ntConnection.getLastAnnouncedValue(model.yTopic)) ??
-                0.0;
-        double zAccel =
-            tryCast(model.ntConnection.getLastAnnouncedValue(model.zTopic)) ??
-                0.0;
-
-        return Column(
-          mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-          mainAxisSize: MainAxisSize.max,
-          children: [
-            // X Acceleration
-            Flexible(
-              flex: 16,
-              child: Row(
-                mainAxisSize: MainAxisSize.max,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Text('X'),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Container(
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surface,
-                        borderRadius: BorderRadius.circular(5.0),
-                      ),
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: Text(
-                        '${xAccel.toStringAsFixed(2)} g',
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.onSurface,
-                          overflow: TextOverflow.ellipsis,
-                          fontSize: 12.0,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
+    return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      mainAxisSize: MainAxisSize.max,
+      children: [
+        // X Acceleration
+        Flexible(
+          flex: 16,
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('X'),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.surface,
+                    borderRadius: BorderRadius.circular(5.0),
                   ),
-                ],
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: ValueListenableBuilder(
+                      valueListenable: model.xSubscription,
+                      builder: (context, value, child) {
+                        double xAccel = tryCast(value) ?? 0.0;
+                        return Text(
+                          '${xAccel.toStringAsFixed(2)} g',
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.onSurface,
+                            overflow: TextOverflow.ellipsis,
+                            fontSize: 12.0,
+                          ),
+                          textAlign: TextAlign.center,
+                        );
+                      }),
+                ),
               ),
-            ),
-            const Flexible(
-              child: SizedBox(height: 4.0),
-            ),
-            // Y Acceleration
-            Flexible(
-              flex: 16,
-              child: Row(
-                mainAxisSize: MainAxisSize.max,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Text('Y'),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Container(
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surface,
-                        borderRadius: BorderRadius.circular(5.0),
-                      ),
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: Text(
-                        '${yAccel.toStringAsFixed(2)} g',
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.onSurface,
-                          overflow: TextOverflow.ellipsis,
-                          fontSize: 12.0,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
+            ],
+          ),
+        ),
+        const Flexible(
+          child: SizedBox(height: 4.0),
+        ),
+        // Y Acceleration
+        Flexible(
+          flex: 16,
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('Y'),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.surface,
+                    borderRadius: BorderRadius.circular(5.0),
                   ),
-                ],
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: ValueListenableBuilder(
+                      valueListenable: model.ySubscription,
+                      builder: (context, value, child) {
+                        double yAccel = tryCast(value) ?? 0.0;
+                        return Text(
+                          '${yAccel.toStringAsFixed(2)} g',
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.onSurface,
+                            overflow: TextOverflow.ellipsis,
+                            fontSize: 12.0,
+                          ),
+                          textAlign: TextAlign.center,
+                        );
+                      }),
+                ),
               ),
-            ),
-            const Flexible(
-              child: SizedBox(height: 4.0),
-            ),
-            // Z Acceleration
-            Flexible(
-              flex: 16,
-              child: Row(
-                mainAxisSize: MainAxisSize.max,
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Text('Z'),
-                  const SizedBox(width: 10),
-                  Expanded(
-                    child: Container(
-                      decoration: BoxDecoration(
-                        color: Theme.of(context).colorScheme.surface,
-                        borderRadius: BorderRadius.circular(5.0),
-                      ),
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: Text(
-                        '${zAccel.toStringAsFixed(2)} g',
-                        style: TextStyle(
-                          color: Theme.of(context).colorScheme.onSurface,
-                          overflow: TextOverflow.ellipsis,
-                          fontSize: 12.0,
-                        ),
-                        textAlign: TextAlign.center,
-                      ),
-                    ),
+            ],
+          ),
+        ),
+        const Flexible(
+          child: SizedBox(height: 4.0),
+        ),
+        // Z Acceleration
+        Flexible(
+          flex: 16,
+          child: Row(
+            mainAxisSize: MainAxisSize.max,
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              const Text('Z'),
+              const SizedBox(width: 10),
+              Expanded(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Theme.of(context).colorScheme.surface,
+                    borderRadius: BorderRadius.circular(5.0),
                   ),
-                ],
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                  child: ValueListenableBuilder(
+                      valueListenable: model.zSubscription,
+                      builder: (context, value, child) {
+                        double zAccel = tryCast(value) ?? 0.0;
+                        return Text(
+                          '${zAccel.toStringAsFixed(2)} g',
+                          style: TextStyle(
+                            color: Theme.of(context).colorScheme.onSurface,
+                            overflow: TextOverflow.ellipsis,
+                            fontSize: 12.0,
+                          ),
+                          textAlign: TextAlign.center,
+                        );
+                      }),
+                ),
               ),
-            ),
-          ],
-        );
-      },
+            ],
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/widgets/nt_widgets/multi-topic/three_axis_accelerometer.dart
+++ b/lib/widgets/nt_widgets/multi-topic/three_axis_accelerometer.dart
@@ -5,7 +5,7 @@ import 'package:provider/provider.dart';
 
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class ThreeAxisAccelerometerModel extends NTWidgetModel {
+class ThreeAxisAccelerometerModel extends SingleTopicNTWidgetModel {
   @override
   String type = ThreeAxisAccelerometer.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/ultrasonic.dart
+++ b/lib/widgets/nt_widgets/multi-topic/ultrasonic.dart
@@ -6,13 +6,16 @@ import 'package:provider/provider.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class UltrasonicModel extends SingleTopicNTWidgetModel {
+class UltrasonicModel extends MultiTopicNTWidgetModel {
   @override
   String type = Ultrasonic.widgetType;
 
   String get valueTopic => '$topic/Value';
 
   late NT4Subscription valueSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [valueSubscription];
 
   UltrasonicModel({
     required super.ntConnection,
@@ -29,26 +32,8 @@ class UltrasonicModel extends SingleTopicNTWidgetModel {
   }) : super.fromJson();
 
   @override
-  void init() {
-    super.init();
-
+  void initializeSubscriptions() {
     valueSubscription = ntConnection.subscribe(valueTopic, super.period);
-  }
-
-  @override
-  void resetSubscription() {
-    ntConnection.unSubscribe(valueSubscription);
-
-    valueSubscription = ntConnection.subscribe(valueTopic, super.period);
-
-    super.resetSubscription();
-  }
-
-  @override
-  void unSubscribe() {
-    ntConnection.unSubscribe(valueSubscription);
-
-    super.unSubscribe();
   }
 }
 
@@ -61,39 +46,37 @@ class Ultrasonic extends NTWidget {
   Widget build(BuildContext context) {
     UltrasonicModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.valueSubscription.periodicStream(yieldAll: false),
-      initialData: model.ntConnection.getLastAnnouncedValue(model.valueTopic),
-      builder: (context, snapshot) {
-        double value = tryCast(snapshot.data) ?? 0.0;
-
-        return Row(
-          children: [
-            const Text('Range'),
-            const SizedBox(width: 10),
-            Expanded(
-              child: Container(
-                decoration: BoxDecoration(
-                  border: Border(
-                    bottom: BorderSide(
-                      color: Colors.grey.shade700,
-                      width: 1.5,
-                    ),
-                  ),
+    return Row(
+      children: [
+        const Text('Range'),
+        const SizedBox(width: 10),
+        Expanded(
+          child: Container(
+            decoration: BoxDecoration(
+              border: Border(
+                bottom: BorderSide(
+                  color: Colors.grey.shade700,
+                  width: 1.5,
                 ),
-                child: SelectableText(
+              ),
+            ),
+            child: ValueListenableBuilder(
+              valueListenable: model.valueSubscription,
+              builder: (context, data, child) {
+                double value = tryCast(data) ?? 0.0;
+                return SelectableText(
                   '${value.toStringAsPrecision(5)} in',
                   maxLines: 1,
                   showCursor: true,
                   style: Theme.of(context).textTheme.bodyLarge?.copyWith(
                         overflow: TextOverflow.ellipsis,
                       ),
-                ),
-              ),
+                );
+              },
             ),
-          ],
-        );
-      },
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/widgets/nt_widgets/multi-topic/ultrasonic.dart
+++ b/lib/widgets/nt_widgets/multi-topic/ultrasonic.dart
@@ -6,7 +6,7 @@ import 'package:provider/provider.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class UltrasonicModel extends NTWidgetModel {
+class UltrasonicModel extends SingleTopicNTWidgetModel {
   @override
   String type = Ultrasonic.widgetType;
 

--- a/lib/widgets/nt_widgets/multi-topic/yagsl_swerve_drive.dart
+++ b/lib/widgets/nt_widgets/multi-topic/yagsl_swerve_drive.dart
@@ -1,12 +1,12 @@
 import 'dart:math';
 
-import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:flutter/material.dart';
 
 import 'package:dot_cast/dot_cast.dart';
 import 'package:provider/provider.dart';
 import 'package:vector_math/vector_math_64.dart' show radians;
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/services/text_formatter_builder.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';

--- a/lib/widgets/nt_widgets/multi-topic/yagsl_swerve_drive.dart
+++ b/lib/widgets/nt_widgets/multi-topic/yagsl_swerve_drive.dart
@@ -1,5 +1,6 @@
 import 'dart:math';
 
+import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:flutter/material.dart';
 
 import 'package:dot_cast/dot_cast.dart';
@@ -11,7 +12,7 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart'
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class YAGSLSwerveDriveModel extends SingleTopicNTWidgetModel {
+class YAGSLSwerveDriveModel extends MultiTopicNTWidgetModel {
   @override
   String type = YAGSLSwerveDrive.widgetType;
 
@@ -22,6 +23,25 @@ class YAGSLSwerveDriveModel extends SingleTopicNTWidgetModel {
   String get robotWidthTopic => '$topic/sizeLeftRight';
   String get robotLengthTopic => '$topic/sizeFrontBack';
   String get rotationUnitTopic => '$topic/rotationUnit';
+
+  late NT4Subscription measuredStatesSubscription;
+  late NT4Subscription desiredStatesSubscription;
+  late NT4Subscription robotRotationSubscription;
+  late NT4Subscription maxSpeedSubscription;
+  late NT4Subscription robotWidthSubscription;
+  late NT4Subscription robotLengthSubscription;
+  late NT4Subscription rotationUnitSubscription;
+
+  @override
+  List<NT4Subscription> get subscriptions => [
+        measuredStatesSubscription,
+        desiredStatesSubscription,
+        robotRotationSubscription,
+        maxSpeedSubscription,
+        robotWidthSubscription,
+        robotLengthSubscription,
+        rotationUnitSubscription,
+      ];
 
   bool _showRobotRotation = true;
   bool _showDesiredStates = true;
@@ -71,6 +91,23 @@ class YAGSLSwerveDriveModel extends SingleTopicNTWidgetModel {
     _showRobotRotation = tryCast(jsonData['show_robot_rotation']) ?? true;
     _showDesiredStates = tryCast(jsonData['show_desired_states']) ?? true;
     _angleOffset = tryCast(jsonData['angle_offset']) ?? 0.0;
+  }
+
+  @override
+  void initializeSubscriptions() {
+    measuredStatesSubscription =
+        ntConnection.subscribe(measuredStatesTopic, super.period);
+    desiredStatesSubscription =
+        ntConnection.subscribe(desiredStatesTopic, super.period);
+    robotRotationSubscription =
+        ntConnection.subscribe(robotRotationTopic, super.period);
+    maxSpeedSubscription = ntConnection.subscribe(maxSpeedTopic, super.period);
+    robotWidthSubscription =
+        ntConnection.subscribe(robotWidthTopic, super.period);
+    robotLengthSubscription =
+        ntConnection.subscribe(robotLengthTopic, super.period);
+    rotationUnitSubscription =
+        ntConnection.subscribe(rotationUnitTopic, super.period);
   }
 
   @override
@@ -130,43 +167,6 @@ class YAGSLSwerveDriveModel extends SingleTopicNTWidgetModel {
       ),
     ];
   }
-
-  @override
-  List<Object> getCurrentData() {
-    List<Object?> measuredStatesRaw =
-        tryCast(ntConnection.getLastAnnouncedValue(measuredStatesTopic)) ?? [];
-    List<Object?> desiredStatesRaw =
-        tryCast(ntConnection.getLastAnnouncedValue(desiredStatesTopic)) ?? [];
-
-    List<double> measuredStates =
-        measuredStatesRaw.whereType<double>().toList();
-    List<double> desiredStates = desiredStatesRaw.whereType<double>().toList();
-
-    double width =
-        tryCast(ntConnection.getLastAnnouncedValue(robotWidthTopic)) ?? 1.0;
-    double length =
-        tryCast(ntConnection.getLastAnnouncedValue(robotLengthTopic)) ?? width;
-
-    String rotationUnit =
-        tryCast(ntConnection.getLastAnnouncedValue(rotationUnitTopic)) ??
-            'radians';
-
-    double robotAngle =
-        tryCast(ntConnection.getLastAnnouncedValue(robotRotationTopic)) ?? 0.0;
-
-    double maxSpeed =
-        tryCast(ntConnection.getLastAnnouncedValue(maxSpeedTopic)) ?? 4.5;
-
-    return [
-      ...measuredStates,
-      ...desiredStates,
-      width,
-      length,
-      rotationUnit,
-      robotAngle,
-      maxSpeed,
-    ];
-  }
 }
 
 class YAGSLSwerveDrive extends NTWidget {
@@ -178,27 +178,21 @@ class YAGSLSwerveDrive extends NTWidget {
   Widget build(BuildContext context) {
     YAGSLSwerveDriveModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.multiTopicPeriodicStream,
+    return ListenableBuilder(
+      listenable: Listenable.merge(model.subscriptions),
       builder: (context, snapshot) {
-        List<Object?> measuredStatesRaw = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.measuredStatesTopic)) ??
-            [];
-        List<Object?> desiredStatesRaw = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.desiredStatesTopic)) ??
-            [];
+        List<Object?> measuredStatesRaw =
+            tryCast(model.measuredStatesSubscription.value) ?? [];
+        List<Object?> desiredStatesRaw =
+            tryCast(model.desiredStatesSubscription.value) ?? [];
 
         List<double> measuredStates =
             measuredStatesRaw.whereType<double>().toList();
         List<double> desiredStates =
             desiredStatesRaw.whereType<double>().toList();
 
-        double width = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.robotWidthTopic)) ??
-            1.0;
-        double length = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.robotLengthTopic)) ??
-            width;
+        double width = tryCast(model.robotWidthSubscription.value) ?? 1.0;
+        double length = tryCast(model.robotLengthSubscription.value) ?? width;
 
         if (width <= 0.0) {
           width = 1.0;
@@ -210,13 +204,11 @@ class YAGSLSwerveDrive extends NTWidget {
         double sizeRatio = min(length, width) / max(length, width);
         double lengthWidthRatio = length / width;
 
-        String rotationUnit = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.rotationUnitTopic)) ??
-            'radians';
+        String rotationUnit =
+            tryCast(model.rotationUnitSubscription.value) ?? 'radians';
 
-        double robotAngle = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.robotRotationTopic)) ??
-            0.0;
+        double robotAngle =
+            tryCast(model.robotRotationSubscription.value) ?? 0.0;
 
         if (rotationUnit == 'degrees') {
           robotAngle = radians(robotAngle);
@@ -226,9 +218,7 @@ class YAGSLSwerveDrive extends NTWidget {
 
         robotAngle -= radians(model.angleOffset);
 
-        double maxSpeed = tryCast(model.ntConnection
-                .getLastAnnouncedValue(model.maxSpeedTopic)) ??
-            4.5;
+        double maxSpeed = tryCast(model.maxSpeedSubscription.value) ?? 4.5;
 
         if (maxSpeed <= 0.0) {
           maxSpeed = 4.5;

--- a/lib/widgets/nt_widgets/multi-topic/yagsl_swerve_drive.dart
+++ b/lib/widgets/nt_widgets/multi-topic/yagsl_swerve_drive.dart
@@ -11,7 +11,7 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart'
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class YAGSLSwerveDriveModel extends NTWidgetModel {
+class YAGSLSwerveDriveModel extends SingleTopicNTWidgetModel {
   @override
   String type = YAGSLSwerveDrive.widgetType;
 

--- a/lib/widgets/nt_widgets/nt_widget.dart
+++ b/lib/widgets/nt_widgets/nt_widget.dart
@@ -303,7 +303,7 @@ class MultiTopicNTWidgetModel extends NTWidgetModel {
     required super.ntConnection,
     required super.preferences,
     required super.topic,
-    String dataType = "", // To allow for stubbing in NTWidgetBuilder
+    String dataType = '', // To allow for stubbing in NTWidgetBuilder
     super.period,
   }) : super();
 

--- a/lib/widgets/nt_widgets/nt_widget.dart
+++ b/lib/widgets/nt_widgets/nt_widget.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 
-import 'package:collection/collection.dart';
 import 'package:dot_cast/dot_cast.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -261,35 +260,6 @@ class SingleTopicNTWidgetModel extends NTWidgetModel {
     }
 
     refresh();
-  }
-
-  static final Function listEquals = const DeepCollectionEquality().equals;
-
-  @protected
-  List<Object> getCurrentData() {
-    return [];
-  }
-
-  Stream<Object> get multiTopicPeriodicStream async* {
-    final Duration delayTime = Duration(
-        microseconds: ((subscription?.options.periodicRateSeconds ??
-                    preferences.getDouble(PrefKeys.defaultPeriod) ??
-                    Defaults.defaultPeriod) *
-                1e6)
-            .round());
-
-    int previousHash = Object.hashAll(getCurrentData());
-
-    while (true) {
-      int currentHash = Object.hashAll(getCurrentData());
-
-      if (previousHash != currentHash) {
-        yield Object();
-        previousHash = currentHash;
-      }
-
-      await Future.delayed(delayTime);
-    }
   }
 }
 

--- a/lib/widgets/nt_widgets/nt_widget.dart
+++ b/lib/widgets/nt_widgets/nt_widget.dart
@@ -20,15 +20,16 @@ import 'package:elastic_dashboard/widgets/nt_widgets/single_topic/toggle_button.
 import 'package:elastic_dashboard/widgets/nt_widgets/single_topic/toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/single_topic/voltage_view.dart';
 
-class NTWidgetModel extends ChangeNotifier {
+abstract class NTWidgetModel extends ChangeNotifier {
+  String get type;
+
   final NTConnection ntConnection;
   final SharedPreferences preferences;
 
-  String _typeOverride = 'NTWidget';
-  String get type => _typeOverride;
+  late double _period;
 
   late String _topic;
-  late double _period;
+
   get topic => _topic;
 
   set topic(value) => _topic = value;
@@ -37,11 +38,6 @@ class NTWidgetModel extends ChangeNotifier {
 
   set period(value) => _period = value;
 
-  String dataType = 'Unknown';
-
-  NT4Subscription? subscription;
-  NT4Topic? ntTopic;
-
   bool _disposed = false;
   bool _forceDispose = false;
 
@@ -49,25 +45,8 @@ class NTWidgetModel extends ChangeNotifier {
     required this.ntConnection,
     required this.preferences,
     required String topic,
-    this.dataType = 'Unknown',
     double? period,
   }) : _topic = topic {
-    this.period = period ??
-        preferences.getDouble(PrefKeys.defaultPeriod) ??
-        Defaults.defaultPeriod;
-
-    init();
-  }
-
-  NTWidgetModel.createDefault({
-    required this.ntConnection,
-    required this.preferences,
-    required String type,
-    required String topic,
-    this.dataType = 'Unknown',
-    double? period,
-  })  : _typeOverride = type,
-        _topic = topic {
     this.period = period ??
         preferences.getDouble(PrefKeys.defaultPeriod) ??
         Defaults.defaultPeriod;
@@ -81,14 +60,99 @@ class NTWidgetModel extends ChangeNotifier {
     required Map<String, dynamic> jsonData,
   }) {
     _topic = tryCast(jsonData['topic']) ?? '';
+
     _period = tryCast(jsonData['period']) ??
         preferences.getDouble(PrefKeys.defaultPeriod) ??
         Defaults.defaultPeriod;
-    dataType = tryCast(jsonData['data_type']) ?? dataType;
 
     init();
   }
 
+  @mustCallSuper
+  Map<String, dynamic> toJson() {
+    return {
+      'topic': topic,
+      'period': period,
+    };
+  }
+
+  void init();
+
+  void unSubscribe();
+
+  void disposeWidget({bool deleting = false});
+
+  void resetSubscription();
+
+  List<String> getAvailableDisplayTypes();
+
+  List<Widget> getEditProperties(BuildContext context) {
+    return const [];
+  }
+
+  void forceDispose() {
+    _forceDispose = true;
+    dispose();
+  }
+
+  @override
+  void dispose() {
+    if (!hasListeners || _forceDispose) {
+      super.dispose();
+
+      _disposed = true;
+    }
+  }
+
+  @override
+  void notifyListeners() {
+    if (!_disposed) {
+      super.notifyListeners();
+    }
+  }
+
+  void refresh() {
+    Future(() => notifyListeners());
+  }
+}
+
+class SingleTopicNTWidgetModel extends NTWidgetModel {
+  String _typeOverride = 'NTWidget';
+  @override
+  String get type => _typeOverride;
+
+  String dataType = 'Unknown';
+
+  NT4Subscription? subscription;
+  NT4Topic? ntTopic;
+
+  SingleTopicNTWidgetModel({
+    required super.ntConnection,
+    required super.preferences,
+    required super.topic,
+    this.dataType = 'Unknown',
+    super.period,
+  }) : super();
+
+  SingleTopicNTWidgetModel.createDefault({
+    required super.ntConnection,
+    required super.preferences,
+    required String type,
+    required super.topic,
+    this.dataType = 'Unknown',
+    super.period,
+  })  : _typeOverride = type,
+        super();
+
+  SingleTopicNTWidgetModel.fromJson({
+    required super.ntConnection,
+    required super.preferences,
+    required Map<String, dynamic> jsonData,
+  }) : super.fromJson(jsonData: jsonData) {
+    dataType = tryCast(jsonData['data_type']) ?? dataType;
+  }
+
+  @override
   @mustCallSuper
   Map<String, dynamic> toJson() {
     if (dataType == 'Unknown' && ntConnection.isNT4Connected) {
@@ -96,21 +160,13 @@ class NTWidgetModel extends ChangeNotifier {
       dataType = ntTopic?.type ?? dataType;
     }
     return {
-      'topic': _topic,
-      'period': period,
+      ...super.toJson(),
       if (dataType != 'Unknown') 'data_type': dataType,
     };
   }
 
-  List<Widget> getEditProperties(BuildContext context) {
-    return const [];
-  }
-
+  @override
   List<String> getAvailableDisplayTypes() {
-    if (type == 'ComboBox Chooser' || type == 'Split Button Chooser') {
-      return ['ComboBox Chooser', 'Split Button Chooser'];
-    }
-
     createTopicIfNull();
     dataType = ntTopic?.type ?? dataType;
 
@@ -156,6 +212,7 @@ class NTWidgetModel extends ChangeNotifier {
     return [type];
   }
 
+  @override
   @mustCallSuper
   void init() async {
     subscription = ntConnection.subscribe(_topic, _period);
@@ -165,6 +222,7 @@ class NTWidgetModel extends ChangeNotifier {
     ntTopic ??= ntConnection.getTopicFromName(_topic);
   }
 
+  @override
   void unSubscribe() {
     if (subscription != null) {
       ntConnection.unSubscribe(subscription!);
@@ -172,8 +230,10 @@ class NTWidgetModel extends ChangeNotifier {
     refresh();
   }
 
+  @override
   void disposeWidget({bool deleting = false}) {}
 
+  @override
   void resetSubscription() {
     if (subscription == null) {
       subscription = ntConnection.subscribe(_topic, _period);
@@ -231,31 +291,63 @@ class NTWidgetModel extends ChangeNotifier {
       await Future.delayed(delayTime);
     }
   }
+}
 
-  void forceDispose() {
-    _forceDispose = true;
-    dispose();
-  }
+class MultiTopicNTWidgetModel extends NTWidgetModel {
+  @override
+  String get type => 'NTWidget';
+
+  List<NT4Subscription> get subscriptions => [];
+
+  MultiTopicNTWidgetModel({
+    required super.ntConnection,
+    required super.preferences,
+    required super.topic,
+    String dataType = "", // To allow for stubbing in NTWidgetBuilder
+    super.period,
+  }) : super();
+
+  MultiTopicNTWidgetModel.fromJson({
+    required super.ntConnection,
+    required super.preferences,
+    required super.jsonData,
+  }) : super.fromJson();
 
   @override
-  void dispose() {
-    if (!hasListeners || _forceDispose) {
-      super.dispose();
+  @mustCallSuper
+  void init() {
+    initializeSubscriptions();
+  }
 
-      _disposed = true;
+  void initializeSubscriptions() {}
+
+  @override
+  void unSubscribe() {
+    for (NT4Subscription subscription in subscriptions) {
+      ntConnection.unSubscribe(subscription);
     }
   }
 
   @override
-  void notifyListeners() {
-    if (!_disposed) {
-      super.notifyListeners();
+  void resetSubscription() {
+    for (NT4Subscription subscription in subscriptions) {
+      ntConnection.unSubscribe(subscription);
     }
+
+    initializeSubscriptions();
   }
 
-  void refresh() {
-    Future(() => notifyListeners());
+  @override
+  List<String> getAvailableDisplayTypes() {
+    if (type == 'ComboBox Chooser' || type == 'Split Button Chooser') {
+      return ['ComboBox Chooser', 'Split Button Chooser'];
+    }
+
+    return [type];
   }
+
+  @override
+  void disposeWidget({bool deleting = false}) {}
 }
 
 abstract class NTWidget extends StatelessWidget {

--- a/lib/widgets/nt_widgets/nt_widget.dart
+++ b/lib/widgets/nt_widgets/nt_widget.dart
@@ -215,11 +215,11 @@ class SingleTopicNTWidgetModel extends NTWidgetModel {
   @override
   @mustCallSuper
   void init() async {
-    subscription = ntConnection.subscribe(_topic, _period);
+    subscription = ntConnection.subscribe(topic, period);
   }
 
   void createTopicIfNull() {
-    ntTopic ??= ntConnection.getTopicFromName(_topic);
+    ntTopic ??= ntConnection.getTopicFromName(topic);
   }
 
   @override
@@ -236,7 +236,7 @@ class SingleTopicNTWidgetModel extends NTWidgetModel {
   @override
   void resetSubscription() {
     if (subscription == null) {
-      subscription = ntConnection.subscribe(_topic, _period);
+      subscription = ntConnection.subscribe(topic, period);
 
       ntTopic = null;
 
@@ -247,7 +247,7 @@ class SingleTopicNTWidgetModel extends NTWidgetModel {
     bool resetDataType = subscription!.topic != topic;
 
     ntConnection.unSubscribe(subscription!);
-    subscription = ntConnection.subscribe(_topic, _period);
+    subscription = ntConnection.subscribe(topic, period);
 
     ntTopic = null;
 

--- a/lib/widgets/nt_widgets/single_topic/boolean_box.dart
+++ b/lib/widgets/nt_widgets/single_topic/boolean_box.dart
@@ -7,7 +7,7 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_color_picker.dar
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_dropdown_chooser.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class BooleanBoxModel extends NTWidgetModel {
+class BooleanBoxModel extends SingleTopicNTWidgetModel {
   @override
   String type = BooleanBox.widgetType;
 
@@ -204,11 +204,10 @@ class BooleanBox extends NTWidget {
   Widget build(BuildContext context) {
     BooleanBoxModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.subscription?.periodicStream(yieldAll: false),
-      initialData: model.ntConnection.getLastAnnouncedValue(model.topic),
-      builder: (context, snapshot) {
-        bool value = tryCast(snapshot.data) ?? false;
+    return ValueListenableBuilder(
+      valueListenable: model.subscription!.value,
+      builder: (context, data, child) {
+        bool value = tryCast(data) ?? false;
 
         Widget defaultWidget() => Container(
               decoration: BoxDecoration(
@@ -248,13 +247,6 @@ class BooleanBox extends NTWidget {
         }
 
         return widgetToDisplay ?? defaultWidget();
-
-        // return Container(
-        //   decoration: BoxDecoration(
-        //     borderRadius: BorderRadius.circular(15.0),
-        //     color: (value) ? model.trueColor : model.falseColor,
-        //   ),
-        // );
       },
     );
   }

--- a/lib/widgets/nt_widgets/single_topic/boolean_box.dart
+++ b/lib/widgets/nt_widgets/single_topic/boolean_box.dart
@@ -205,7 +205,7 @@ class BooleanBox extends NTWidget {
     BooleanBoxModel model = cast(context.watch<NTWidgetModel>());
 
     return ValueListenableBuilder(
-      valueListenable: model.subscription!.value,
+      valueListenable: model.subscription!,
       builder: (context, data, child) {
         bool value = tryCast(data) ?? false;
 

--- a/lib/widgets/nt_widgets/single_topic/graph.dart
+++ b/lib/widgets/nt_widgets/single_topic/graph.dart
@@ -12,7 +12,7 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_color_picker.dar
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class GraphModel extends NTWidgetModel {
+class GraphModel extends SingleTopicNTWidgetModel {
   @override
   String type = GraphWidget.widgetType;
 

--- a/lib/widgets/nt_widgets/single_topic/match_time.dart
+++ b/lib/widgets/nt_widgets/single_topic/match_time.dart
@@ -181,7 +181,7 @@ class MatchTimeWidget extends NTWidget {
     MatchTimeModel model = cast(context.watch<NTWidgetModel>());
 
     return ValueListenableBuilder(
-      valueListenable: model.subscription!.value,
+      valueListenable: model.subscription!,
       builder: (context, data, child) {
         double time = tryCast(data) ?? -1.0;
         time = time.floorToDouble();

--- a/lib/widgets/nt_widgets/single_topic/match_time.dart
+++ b/lib/widgets/nt_widgets/single_topic/match_time.dart
@@ -8,7 +8,7 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_dropdown_chooser
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class MatchTimeModel extends NTWidgetModel {
+class MatchTimeModel extends SingleTopicNTWidgetModel {
   @override
   String type = MatchTimeWidget.widgetType;
 
@@ -180,11 +180,10 @@ class MatchTimeWidget extends NTWidget {
   Widget build(BuildContext context) {
     MatchTimeModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.subscription?.periodicStream(yieldAll: false),
-      initialData: model.ntConnection.getLastAnnouncedValue(model.topic),
-      builder: (context, snapshot) {
-        double time = tryCast(snapshot.data) ?? -1.0;
+    return ValueListenableBuilder(
+      valueListenable: model.subscription!.value,
+      builder: (context, data, child) {
+        double time = tryCast(data) ?? -1.0;
         time = time.floorToDouble();
 
         String timeDisplayString;

--- a/lib/widgets/nt_widgets/single_topic/multi_color_view.dart
+++ b/lib/widgets/nt_widgets/single_topic/multi_color_view.dart
@@ -15,7 +15,7 @@ class MultiColorView extends NTWidget {
     SingleTopicNTWidgetModel model = cast(context.watch<NTWidgetModel>());
 
     return ValueListenableBuilder(
-      valueListenable: model.subscription!.value,
+      valueListenable: model.subscription!,
       builder: (context, data, child) {
         List<Object?> hexStringsRaw = data?.tryCast<List<Object?>>() ?? [];
         List<String> hexStrings = hexStringsRaw.whereType<String>().toList();

--- a/lib/widgets/nt_widgets/single_topic/multi_color_view.dart
+++ b/lib/widgets/nt_widgets/single_topic/multi_color_view.dart
@@ -12,14 +12,12 @@ class MultiColorView extends NTWidget {
 
   @override
   Widget build(BuildContext context) {
-    NTWidgetModel model = context.watch<NTWidgetModel>();
+    SingleTopicNTWidgetModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.subscription?.periodicStream(yieldAll: false),
-      initialData: model.ntConnection.getLastAnnouncedValue(model.topic),
-      builder: (context, snapshot) {
-        List<Object?> hexStringsRaw =
-            snapshot.data?.tryCast<List<Object?>>() ?? [];
+    return ValueListenableBuilder(
+      valueListenable: model.subscription!.value,
+      builder: (context, data, child) {
+        List<Object?> hexStringsRaw = data?.tryCast<List<Object?>>() ?? [];
         List<String> hexStrings = hexStringsRaw.whereType<String>().toList();
 
         List<Color> colors = [];

--- a/lib/widgets/nt_widgets/single_topic/number_bar.dart
+++ b/lib/widgets/nt_widgets/single_topic/number_bar.dart
@@ -12,7 +12,7 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart'
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class NumberBarModel extends NTWidgetModel {
+class NumberBarModel extends SingleTopicNTWidgetModel {
   @override
   String type = NumberBar.widgetType;
 
@@ -206,11 +206,10 @@ class NumberBar extends NTWidget {
   Widget build(BuildContext context) {
     NumberBarModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.subscription?.periodicStream(yieldAll: false),
-      initialData: model.ntConnection.getLastAnnouncedValue(model.topic),
-      builder: (context, snapshot) {
-        double value = tryCast<num>(snapshot.data)?.toDouble() ?? 0.0;
+    return ValueListenableBuilder(
+      valueListenable: model.subscription!.value,
+      builder: (context, data, child) {
+        double value = tryCast<num>(data)?.toDouble() ?? 0.0;
 
         double clampedValue = value.clamp(model.minValue, model.maxValue);
 

--- a/lib/widgets/nt_widgets/single_topic/number_bar.dart
+++ b/lib/widgets/nt_widgets/single_topic/number_bar.dart
@@ -207,7 +207,7 @@ class NumberBar extends NTWidget {
     NumberBarModel model = cast(context.watch<NTWidgetModel>());
 
     return ValueListenableBuilder(
-      valueListenable: model.subscription!.value,
+      valueListenable: model.subscription!,
       builder: (context, data, child) {
         double value = tryCast<num>(data)?.toDouble() ?? 0.0;
 

--- a/lib/widgets/nt_widgets/single_topic/number_slider.dart
+++ b/lib/widgets/nt_widgets/single_topic/number_slider.dart
@@ -200,13 +200,13 @@ class NumberSlider extends NTWidget {
 
     return ListenableBuilder(
       listenable: Listenable.merge([
-        model.subscription!.value,
+        model.subscription!,
         model.displayValue,
         model.dragging,
       ]),
       builder: (context, child) {
         double value =
-            tryCast<num>(model.subscription!.value.value)?.toDouble() ?? 0.0;
+            tryCast<num>(model.subscription!.value)?.toDouble() ?? 0.0;
 
         double clampedValue = value.clamp(model.minValue, model.maxValue);
 

--- a/lib/widgets/nt_widgets/single_topic/radial_gauge.dart
+++ b/lib/widgets/nt_widgets/single_topic/radial_gauge.dart
@@ -302,7 +302,7 @@ class RadialGauge extends NTWidget {
     RadialGaugeModel model = cast(context.watch<NTWidgetModel>());
 
     return ValueListenableBuilder(
-      valueListenable: model.subscription!.value,
+      valueListenable: model.subscription!,
       builder: (context, data, child) {
         double value = tryCast<num>(data)?.toDouble() ?? 0.0;
 

--- a/lib/widgets/nt_widgets/single_topic/radial_gauge.dart
+++ b/lib/widgets/nt_widgets/single_topic/radial_gauge.dart
@@ -11,7 +11,7 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart'
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class RadialGaugeModel extends NTWidgetModel {
+class RadialGaugeModel extends SingleTopicNTWidgetModel {
   @override
   String type = RadialGauge.widgetType;
 
@@ -301,11 +301,10 @@ class RadialGauge extends NTWidget {
   Widget build(BuildContext context) {
     RadialGaugeModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.subscription?.periodicStream(yieldAll: false),
-      initialData: model.ntConnection.getLastAnnouncedValue(model.topic),
-      builder: (context, snapshot) {
-        double value = tryCast<num>(snapshot.data)?.toDouble() ?? 0.0;
+    return ValueListenableBuilder(
+      valueListenable: model.subscription!.value,
+      builder: (context, data, child) {
+        double value = tryCast<num>(data)?.toDouble() ?? 0.0;
 
         if (model.wrapValue) {
           value = _getWrappedValue(value, model.minValue, model.maxValue);

--- a/lib/widgets/nt_widgets/single_topic/single_color_view.dart
+++ b/lib/widgets/nt_widgets/single_topic/single_color_view.dart
@@ -15,7 +15,7 @@ class SingleColorView extends NTWidget {
     SingleTopicNTWidgetModel model = cast(context.watch<NTWidgetModel>());
 
     return ValueListenableBuilder(
-      valueListenable: model.subscription!.value,
+      valueListenable: model.subscription!,
       builder: (context, data, child) {
         String hexString = tryCast(data) ?? '';
 

--- a/lib/widgets/nt_widgets/single_topic/single_color_view.dart
+++ b/lib/widgets/nt_widgets/single_topic/single_color_view.dart
@@ -12,13 +12,12 @@ class SingleColorView extends NTWidget {
 
   @override
   Widget build(BuildContext context) {
-    NTWidgetModel model = context.watch<NTWidgetModel>();
+    SingleTopicNTWidgetModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.subscription?.periodicStream(yieldAll: false),
-      initialData: model.ntConnection.getLastAnnouncedValue(model.topic),
-      builder: (context, snapshot) {
-        String hexString = tryCast(snapshot.data) ?? '';
+    return ValueListenableBuilder(
+      valueListenable: model.subscription!.value,
+      builder: (context, data, child) {
+        String hexString = tryCast(data) ?? '';
 
         hexString = hexString.toUpperCase().replaceAll('#', '');
 

--- a/lib/widgets/nt_widgets/single_topic/text_display.dart
+++ b/lib/widgets/nt_widgets/single_topic/text_display.dart
@@ -142,11 +142,11 @@ class TextDisplay extends NTWidget {
 
     return ListenableBuilder(
       listenable: Listenable.merge([
-        model.subscription!.value,
+        model.subscription!,
         model.controller,
       ]),
       builder: (context, child) {
-        Object? data = model.subscription!.value.value;
+        Object? data = model.subscription!.value;
 
         if (data?.toString() != model.previousValue?.toString()) {
           // Needed to prevent errors

--- a/lib/widgets/nt_widgets/single_topic/text_display.dart
+++ b/lib/widgets/nt_widgets/single_topic/text_display.dart
@@ -10,7 +10,7 @@ import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class TextDisplayModel extends NTWidgetModel {
+class TextDisplayModel extends SingleTopicNTWidgetModel {
   @override
   String type = TextDisplay.widgetType;
 
@@ -140,11 +140,13 @@ class TextDisplay extends NTWidget {
   Widget build(BuildContext context) {
     TextDisplayModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.subscription?.periodicStream(),
-      initialData: model.ntConnection.getLastAnnouncedValue(model.topic),
-      builder: (context, snapshot) {
-        Object? data = snapshot.data;
+    return ListenableBuilder(
+      listenable: Listenable.merge([
+        model.subscription!.value,
+        model.controller,
+      ]),
+      builder: (context, child) {
+        Object? data = model.subscription!.value.value;
 
         if (data?.toString() != model.previousValue?.toString()) {
           // Needed to prevent errors

--- a/lib/widgets/nt_widgets/single_topic/toggle_button.dart
+++ b/lib/widgets/nt_widgets/single_topic/toggle_button.dart
@@ -12,13 +12,12 @@ class ToggleButton extends NTWidget {
 
   @override
   Widget build(BuildContext context) {
-    NTWidgetModel model = context.watch<NTWidgetModel>();
+    SingleTopicNTWidgetModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-        stream: model.subscription?.periodicStream(yieldAll: false),
-        initialData: model.ntConnection.getLastAnnouncedValue(model.topic),
-        builder: (context, snapshot) {
-          bool value = tryCast(snapshot.data) ?? false;
+    return ValueListenableBuilder(
+        valueListenable: model.subscription!.value,
+        builder: (context, data, child) {
+          bool value = tryCast(data) ?? false;
 
           String buttonText =
               model.topic.substring(model.topic.lastIndexOf('/') + 1);

--- a/lib/widgets/nt_widgets/single_topic/toggle_button.dart
+++ b/lib/widgets/nt_widgets/single_topic/toggle_button.dart
@@ -15,7 +15,7 @@ class ToggleButton extends NTWidget {
     SingleTopicNTWidgetModel model = cast(context.watch<NTWidgetModel>());
 
     return ValueListenableBuilder(
-        valueListenable: model.subscription!.value,
+        valueListenable: model.subscription!,
         builder: (context, data, child) {
           bool value = tryCast(data) ?? false;
 

--- a/lib/widgets/nt_widgets/single_topic/toggle_switch.dart
+++ b/lib/widgets/nt_widgets/single_topic/toggle_switch.dart
@@ -12,13 +12,12 @@ class ToggleSwitch extends NTWidget {
 
   @override
   Widget build(BuildContext context) {
-    NTWidgetModel model = context.watch<NTWidgetModel>();
+    SingleTopicNTWidgetModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.subscription?.periodicStream(yieldAll: false),
-      initialData: model.ntConnection.getLastAnnouncedValue(model.topic),
-      builder: (context, snapshot) {
-        bool value = tryCast(snapshot.data) ?? false;
+    return ValueListenableBuilder(
+      valueListenable: model.subscription!.value,
+      builder: (context, data, child) {
+        bool value = tryCast(data) ?? false;
 
         return Switch(
           value: value,

--- a/lib/widgets/nt_widgets/single_topic/toggle_switch.dart
+++ b/lib/widgets/nt_widgets/single_topic/toggle_switch.dart
@@ -15,7 +15,7 @@ class ToggleSwitch extends NTWidget {
     SingleTopicNTWidgetModel model = cast(context.watch<NTWidgetModel>());
 
     return ValueListenableBuilder(
-      valueListenable: model.subscription!.value,
+      valueListenable: model.subscription!,
       builder: (context, data, child) {
         bool value = tryCast(data) ?? false;
 

--- a/lib/widgets/nt_widgets/single_topic/voltage_view.dart
+++ b/lib/widgets/nt_widgets/single_topic/voltage_view.dart
@@ -207,7 +207,7 @@ class VoltageView extends NTWidget {
     VoltageViewModel model = cast(context.watch<NTWidgetModel>());
 
     return ValueListenableBuilder(
-      valueListenable: model.subscription!.value,
+      valueListenable: model.subscription!,
       builder: (context, data, child) {
         double voltage = tryCast<num>(data)?.toDouble() ?? 0.0;
 

--- a/lib/widgets/nt_widgets/single_topic/voltage_view.dart
+++ b/lib/widgets/nt_widgets/single_topic/voltage_view.dart
@@ -12,7 +12,7 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart'
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 
-class VoltageViewModel extends NTWidgetModel {
+class VoltageViewModel extends SingleTopicNTWidgetModel {
   @override
   String type = VoltageView.widgetType;
 
@@ -206,11 +206,10 @@ class VoltageView extends NTWidget {
   Widget build(BuildContext context) {
     VoltageViewModel model = cast(context.watch<NTWidgetModel>());
 
-    return StreamBuilder(
-      stream: model.subscription?.periodicStream(yieldAll: false),
-      initialData: model.ntConnection.getLastAnnouncedValue(model.topic),
-      builder: (context, snapshot) {
-        double voltage = tryCast<num>(snapshot.data)?.toDouble() ?? 0.0;
+    return ValueListenableBuilder(
+      valueListenable: model.subscription!.value,
+      builder: (context, data, child) {
+        double voltage = tryCast<num>(data)?.toDouble() ?? 0.0;
 
         double clampedVoltage = voltage.clamp(model.minValue, model.maxValue);
 

--- a/lib/widgets/tab_grid.dart
+++ b/lib/widgets/tab_grid.dart
@@ -652,7 +652,18 @@ class TabGridModel extends ChangeNotifier {
     refresh();
   }
 
-  void clearWidgets(BuildContext context) {
+  @visibleForTesting
+  void clearWidgets() {
+    for (WidgetContainerModel container in _widgetModels) {
+      container.disposeModel(deleting: true);
+      container.unSubscribe();
+      container.forceDispose();
+    }
+    _widgetModels.clear();
+    refresh();
+  }
+
+  void confirmClearWidgets(BuildContext context) {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
@@ -664,13 +675,7 @@ class TabGridModel extends ChangeNotifier {
             onPressed: () {
               Navigator.of(context).pop();
 
-              for (WidgetContainerModel container in _widgetModels) {
-                container.disposeModel(deleting: true);
-                container.unSubscribe();
-                container.forceDispose();
-              }
-              _widgetModels.clear();
-              refresh();
+              clearWidgets();
             },
             child: const Text('Confirm'),
           ),
@@ -970,7 +975,7 @@ class TabGrid extends StatelessWidget {
           MenuItem(
             label: 'Clear Layout',
             icon: Icons.clear,
-            onSelected: () => model.clearWidgets(context),
+            onSelected: () => model.confirmClearWidgets(context),
           ),
         ];
 

--- a/test/pages/dashboard_page_test.dart
+++ b/test/pages/dashboard_page_test.dart
@@ -1,7 +1,6 @@
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
@@ -16,6 +15,7 @@ import 'package:elastic_dashboard/pages/dashboard_page.dart';
 import 'package:elastic_dashboard/services/field_images.dart';
 import 'package:elastic_dashboard/services/hotkey_manager.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
+import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'package:elastic_dashboard/services/settings.dart';
 import 'package:elastic_dashboard/widgets/custom_appbar.dart';
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart';

--- a/test/services/robot_notifications_listener_test.dart
+++ b/test/services/robot_notifications_listener_test.dart
@@ -14,7 +14,7 @@ class MockNotificationCallback extends Mock {
 }
 
 void main() {
-  test("Robot Notifications (Initial Connection | No Existing Data) ", () {
+  test('Robot Notifications (Initial Connection | No Existing Data) ', () {
     MockNTConnection mockConnection = createMockOnlineNT4();
 
     // Create a mock for the onNotification callback
@@ -39,7 +39,7 @@ void main() {
     verifyNever(mockOnNotification.call(any, any, any));
   });
 
-  test("Robot Notifications (Initial Connection | Old Existing Data) ", () {
+  test('Robot Notifications (Initial Connection | Old Existing Data) ', () {
     MockNTConnection mockConnection = createMockOnlineNT4(serverTime: 5000000);
     MockNT4Subscription mockSub = MockNT4Subscription();
 
@@ -118,7 +118,7 @@ void main() {
     verifyNever(mockOnNotification(any, any, any));
   });
 
-  test("Robot Notifications (Initial Connection | Newer Existing Data) ", () {
+  test('Robot Notifications (Initial Connection | Newer Existing Data) ', () {
     MockNTConnection mockConnection = createMockOnlineNT4(serverTime: 5000000);
     MockNT4Subscription mockSub = MockNT4Subscription();
 

--- a/test/services/shuffleboard_nt_listener_test.dart
+++ b/test/services/shuffleboard_nt_listener_test.dart
@@ -5,6 +5,7 @@ import 'package:shared_preferences/shared_preferences.dart';
 import 'package:elastic_dashboard/services/nt4_client.dart';
 import 'package:elastic_dashboard/services/settings.dart';
 import 'package:elastic_dashboard/services/shuffleboard_nt_listener.dart';
+import '../test_util.dart';
 import '../test_util.mocks.dart';
 
 void main() {
@@ -48,8 +49,6 @@ void main() {
     when(mockNT4Connection.subscribe(any, any)).thenReturn(mockSubscription);
 
     when(mockNT4Connection.subscribe(any)).thenReturn(mockSubscription);
-
-    // NTConnection.instance = mockNT4Connection;
 
     Map<String, dynamic> announcedWidgetData = {};
 
@@ -100,5 +99,34 @@ void main() {
     expect(announcedWidgetData['y'], Defaults.gridSize.toDouble());
     expect(announcedWidgetData['width'], Defaults.gridSize.toDouble() * 2.0);
     expect(announcedWidgetData['height'], Defaults.gridSize.toDouble() * 2.0);
+  });
+
+  test('Tab selection change', () {
+    final ntConnection = createMockOnlineNT4(
+      virtualTopics: [
+        NT4Topic(
+          name: '/Shuffleboard/.metadata/Selected',
+          type: NT4TypeStr.kString,
+          properties: {},
+        ),
+      ],
+    );
+
+    String? selectedTab;
+
+    ShuffleboardNTListener(
+      ntConnection: ntConnection,
+      preferences: preferences,
+      onTabChanged: (tab) {
+        selectedTab = tab;
+      },
+    )
+      ..initializeSubscriptions()
+      ..initializeListeners();
+
+    ntConnection.updateDataFromTopicName(
+        '/Shuffleboard/.metadata/Selected', "Test Tab Selection");
+
+    expect(selectedTab, "Test Tab Selection");
   });
 }

--- a/test/services/shuffleboard_nt_listener_test.dart
+++ b/test/services/shuffleboard_nt_listener_test.dart
@@ -125,8 +125,8 @@ void main() {
       ..initializeListeners();
 
     ntConnection.updateDataFromTopicName(
-        '/Shuffleboard/.metadata/Selected', "Test Tab Selection");
+        '/Shuffleboard/.metadata/Selected', 'Test Tab Selection');
 
-    expect(selectedTab, "Test Tab Selection");
+    expect(selectedTab, 'Test Tab Selection');
   });
 }

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -82,6 +82,8 @@ MockNTConnection createMockOnlineNT4({
     virtualTopicsMap.addAll({i + 1: virtualTopics[i]});
   }
 
+  List<NT4Topic> publishedTopics = [];
+
   when(mockNT4Connection.announcedTopics()).thenReturn(virtualTopicsMap);
 
   when(mockNT4Connection.addTopicAnnounceListener(any))
@@ -127,7 +129,20 @@ MockNTConnection createMockOnlineNT4({
         properties: {});
 
     virtualTopicsMap[virtualTopicsMap.length] = newTopic;
+    publishedTopics.add(newTopic);
     return newTopic;
+  });
+
+  when(mockNT4Connection.publishTopic(any)).thenAnswer((invocation) {
+    publishedTopics.add(invocation.positionalArguments[0]);
+  });
+
+  when(mockNT4Connection.unpublishTopic(any)).thenAnswer((invocation) {
+    publishedTopics.remove(invocation.positionalArguments[0]);
+  });
+
+  when(mockNT4Connection.isTopicPublished(any)).thenAnswer((invocation) {
+    return publishedTopics.contains(invocation.positionalArguments[0]);
   });
 
   when(mockNT4Connection.updateDataFromTopic(any, any))

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -169,7 +169,7 @@ MockNTConnection createMockOnlineNT4({
     });
 
     when(topicSubscription.value = any).thenAnswer((invocation) {
-      virtualValues?[topic.name] = invocation.positionalArguments[0];
+      virtualValues![topic.name] = invocation.positionalArguments[0];
       for (var notifier in subscriptionNotifiers) {
         notifier.call();
       }

--- a/test/test_util.dart
+++ b/test/test_util.dart
@@ -24,7 +24,7 @@ MockNTConnection createMockOfflineNT4() {
 
   when(mockSubscription.periodicStream()).thenAnswer((_) => Stream.value(null));
 
-  when(mockSubscription.listen(any)).thenAnswer((realInvocation) {});
+  when(mockSubscription.listen(any)).thenAnswer((invocation) {});
 
   when(mockNT4Connection.isNT4Connected).thenReturn(false);
 
@@ -87,18 +87,15 @@ MockNTConnection createMockOnlineNT4({
   when(mockNT4Connection.announcedTopics()).thenReturn(virtualTopicsMap);
 
   when(mockNT4Connection.addTopicAnnounceListener(any))
-      .thenAnswer((realInvocation) {
-    if (virtualTopics == null) {
-      return;
-    }
-    for (NT4Topic topic in virtualTopics) {
-      realInvocation.positionalArguments[0].call(topic);
+      .thenAnswer((invocation) {
+    for (NT4Topic topic in virtualTopics!) {
+      invocation.positionalArguments[0].call(topic);
     }
   });
 
   when(mockSubscription.periodicStream()).thenAnswer((_) => Stream.value(null));
 
-  when(mockSubscription.listen(any)).thenAnswer((realInvocation) {});
+  when(mockSubscription.listen(any)).thenAnswer((_) {});
 
   when(mockNT4Connection.isNT4Connected).thenReturn(true);
 
@@ -166,62 +163,66 @@ MockNTConnection createMockOnlineNT4({
     List<void Function()> subscriptionNotifiers = [];
 
     MockNT4Subscription topicSubscription = MockNT4Subscription();
+
     when(topicSubscription.value).thenAnswer((_) {
-      return virtualValues?[topic.name];
+      return virtualValues![topic.name];
     });
-    when(topicSubscription.value = any).thenAnswer((realInvocation) {
-      virtualValues?[topic.name] = realInvocation.positionalArguments[0];
+
+    when(topicSubscription.value = any).thenAnswer((invocation) {
+      virtualValues?[topic.name] = invocation.positionalArguments[0];
       for (var notifier in subscriptionNotifiers) {
         notifier.call();
       }
     });
-    when(topicSubscription.addListener(any)).thenAnswer((realInvocation) {
-      subscriptionNotifiers.add(realInvocation.positionalArguments[0]);
+
+    when(topicSubscription.addListener(any)).thenAnswer((invocation) {
+      subscriptionNotifiers.add(invocation.positionalArguments[0]);
     });
-    when(topicSubscription.removeListener(any)).thenAnswer((realInvocation) {
-      subscriptionNotifiers.remove(realInvocation.positionalArguments[0]);
+
+    when(topicSubscription.removeListener(any)).thenAnswer((invocation) {
+      subscriptionNotifiers.remove(invocation.positionalArguments[0]);
     });
 
     when(mockNT4Connection.updateDataFromTopic(topic, any))
-        .thenAnswer((realInvocation) {
-      virtualValues?[topic.name] = realInvocation.positionalArguments[1];
-      topicSubscription.value = realInvocation.positionalArguments[1];
+        .thenAnswer((invocation) {
+      virtualValues![topic.name] = invocation.positionalArguments[1];
+      topicSubscription.value = invocation.positionalArguments[1];
     });
 
     when(mockNT4Connection.updateDataFromTopicName(topic.name, any))
-        .thenAnswer((realInvocation) {
-      virtualValues?[topic.name] = realInvocation.positionalArguments[1];
-      topicSubscription.value = realInvocation.positionalArguments[1];
+        .thenAnswer((invocation) {
+      virtualValues![topic.name] = invocation.positionalArguments[1];
+      topicSubscription.value = invocation.positionalArguments[1];
     });
 
     when(mockNT4Connection.updateDataFromSubscription(topicSubscription, any))
-        .thenAnswer((realInvocation) {
-      virtualValues?[topic.name] = realInvocation.positionalArguments[1];
-      topicSubscription.value = realInvocation.positionalArguments[1];
+        .thenAnswer((invocation) {
+      virtualValues![topic.name] = invocation.positionalArguments[1];
+      topicSubscription.value = invocation.positionalArguments[1];
     });
 
     when(mockNT4Connection.getTopicFromName(topic.name)).thenReturn(topic);
 
     when(topicSubscription.periodicStream(yieldAll: anyNamed('yieldAll')))
-        .thenAnswer((_) => Stream.value(virtualValues?[topic.name]));
+        .thenAnswer((_) => Stream.value(virtualValues![topic.name]));
 
-    when(topicSubscription.listen(any)).thenAnswer((realInvocation) {
-      subscriptionListeners.add(realInvocation.positionalArguments[0]);
+    when(topicSubscription.listen(any)).thenAnswer((invocation) {
+      subscriptionListeners.add(invocation.positionalArguments[0]);
     });
 
     when(topicSubscription.updateValue(any, any)).thenAnswer(
-      (invoc) {
+      (invocation) {
         for (var value in subscriptionListeners) {
-          value.call(
-              invoc.positionalArguments[0], invoc.positionalArguments[1]);
+          value.call(invocation.positionalArguments[0],
+              invocation.positionalArguments[1]);
         }
-        virtualValues?[topic.name] = invoc.positionalArguments[1];
-        topicSubscription.value = invoc.positionalArguments[1];
+        virtualValues![topic.name] = invocation.positionalArguments[1];
+        topicSubscription.value = invocation.positionalArguments[1];
       },
     );
 
     when(mockNT4Connection.getLastAnnouncedValue(topic.name))
-        .thenAnswer((_) => virtualValues?[topic.name]);
+        .thenAnswer((_) => virtualValues![topic.name]);
 
     when(mockNT4Connection.subscribe(topic.name, any))
         .thenAnswer((_) => topicSubscription);

--- a/test/widgets/editable_tab_bar_test.dart
+++ b/test/widgets/editable_tab_bar_test.dart
@@ -2,7 +2,6 @@ import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -12,32 +11,30 @@ import 'package:elastic_dashboard/widgets/editable_tab_bar.dart';
 import 'package:elastic_dashboard/widgets/tab_grid.dart';
 import '../test_util.dart';
 import '../test_util.mocks.dart';
-import 'editable_tab_bar_test.mocks.dart';
 
-@GenerateNiceMocks([MockSpec<FakeTabBarFunctions>()])
-class FakeTabBarFunctions {
-  void onTabCreate() {}
+class FakeTabBarFunctions extends Mock {
+  void onTabCreate();
 
-  void onTabDestroy() {}
+  void onTabDestroy();
 
-  void onTabMoveLeft() {}
+  void onTabMoveLeft();
 
-  void onTabMoveRight() {}
+  void onTabMoveRight();
 
-  void onTabRename() {}
+  void onTabRename();
 
-  void onTabChanged() {}
+  void onTabChanged();
 
-  void onTabDuplicate() {}
+  void onTabDuplicate();
 }
 
 void main() {
-  late MockFakeTabBarFunctions tabBarFunctions;
+  late FakeTabBarFunctions tabBarFunctions;
   late MockNTConnection mockNTConnection;
   late SharedPreferences preferences;
 
   setUp(() async {
-    tabBarFunctions = MockFakeTabBarFunctions();
+    tabBarFunctions = FakeTabBarFunctions();
     SharedPreferences.setMockInitialValues({});
     preferences = await SharedPreferences.getInstance();
     mockNTConnection = createMockOfflineNT4();

--- a/test/widgets/nt_widgets/multi-topic/robot_preferences_test.dart
+++ b/test/widgets/nt_widgets/multi-topic/robot_preferences_test.dart
@@ -1,15 +1,16 @@
 import 'package:flutter/material.dart';
 
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 import 'package:elastic_dashboard/services/nt4_client.dart';
-import 'package:elastic_dashboard/services/nt_connection.dart';
 import 'package:elastic_dashboard/services/nt_widget_builder.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/multi-topic/robot_preferences.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
 import '../../../test_util.dart';
+import '../../../test_util.mocks.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -20,7 +21,7 @@ void main() {
   };
 
   late SharedPreferences preferences;
-  late NTConnection ntConnection;
+  late MockNTConnection ntConnection;
 
   setUp(() async {
     SharedPreferences.setMockInitialValues({});
@@ -109,35 +110,66 @@ void main() {
     expect(find.widgetWithText(TextField, 'Test Preference'), findsOneWidget);
     await widgetTester.enterText(
         find.widgetWithText(TextField, 'Test Preference'), '1');
+    // Focusing on the text field should publish the topic
+    verify(ntConnection.publishTopic(any)).called(1);
+
     await widgetTester.testTextInput.receiveAction(TextInputAction.done);
 
     expect(
         ntConnection.getLastAnnouncedValue('Test/Preferences/Test Preference'),
         1);
 
+    // After submitting topic should be unpublished
+    verify(ntConnection.unpublishTopic(any)).called(1);
+
+    clearInteractions(ntConnection);
+
     expect(find.widgetWithText(TextField, 'Preference 1'), findsOneWidget);
     await widgetTester.enterText(
         find.widgetWithText(TextField, 'Preference 1'), '0.250');
+    // Focusing on the text field should publish the topic
+    verify(ntConnection.publishTopic(any)).called(1);
+
     await widgetTester.testTextInput.receiveAction(TextInputAction.done);
 
     expect(ntConnection.getLastAnnouncedValue('Test/Preferences/Preference 1'),
         0.250);
 
+    // After submitting topic should be unpublished
+    verify(ntConnection.unpublishTopic(any)).called(1);
+
+    clearInteractions(ntConnection);
+
     expect(find.widgetWithText(TextField, 'Preference 2'), findsOneWidget);
     await widgetTester.enterText(
         find.widgetWithText(TextField, 'Preference 2'), 'true');
+    // Focusing on the text field should publish the topic
+    verify(ntConnection.publishTopic(any)).called(1);
+
     await widgetTester.testTextInput.receiveAction(TextInputAction.done);
 
     expect(ntConnection.getLastAnnouncedValue('Test/Preferences/Preference 2'),
         isTrue);
 
+    // After submitting topic should be unpublished
+    verify(ntConnection.unpublishTopic(any)).called(1);
+
+    clearInteractions(ntConnection);
+
     expect(find.widgetWithText(TextField, 'Preference 3'), findsOneWidget);
     await widgetTester.enterText(
         find.widgetWithText(TextField, 'Preference 3'), 'Edited String');
+    // Focusing on the text field should publish the topic
+    verify(ntConnection.publishTopic(any)).called(1);
+
     await widgetTester.testTextInput.receiveAction(TextInputAction.done);
 
     expect(ntConnection.getLastAnnouncedValue('Test/Preferences/Preference 3'),
         'Edited String');
+    // After submitting topic should be unpublished
+    verify(ntConnection.unpublishTopic(any)).called(1);
+
+    clearInteractions(ntConnection);
 
     // Searching
     final searchField = find.widgetWithText(TextField, 'Search');

--- a/test/widgets/nt_widgets/single-topic/multi_color_view_test.dart
+++ b/test/widgets/nt_widgets/single-topic/multi_color_view_test.dart
@@ -79,7 +79,7 @@ void main() {
   });
 
   test('Multi color view to json', () {
-    NTWidgetModel multiColorViewModel = NTWidgetModel.createDefault(
+    NTWidgetModel multiColorViewModel = SingleTopicNTWidgetModel.createDefault(
       ntConnection: ntConnection,
       preferences: preferences,
       type: 'Multi Color View',

--- a/test/widgets/nt_widgets/single-topic/multi_color_view_test.dart
+++ b/test/widgets/nt_widgets/single-topic/multi_color_view_test.dart
@@ -69,7 +69,7 @@ void main() {
     );
 
     expect(multiColorViewModel.type, 'Multi Color View');
-    expect(multiColorViewModel.runtimeType, NTWidgetModel);
+    expect(multiColorViewModel.runtimeType, SingleTopicNTWidgetModel);
     expect(
         multiColorViewModel.getAvailableDisplayTypes(),
         unorderedEquals([

--- a/test/widgets/nt_widgets/single-topic/number_slider_test.dart
+++ b/test/widgets/nt_widgets/single-topic/number_slider_test.dart
@@ -133,7 +133,8 @@ void main() {
     Object? valueDuringDrag;
 
     Future.delayed(const Duration(milliseconds: 500), () {
-      draggingDuringDrag = (numberSliderModel as NumberSliderModel).dragging;
+      draggingDuringDrag =
+          (numberSliderModel as NumberSliderModel).dragging.value;
       valueDuringDrag = ntConnection.getLastAnnouncedValue('Test/Double Value');
     });
 
@@ -190,7 +191,7 @@ void main() {
     Object? valueDuringDrag;
 
     Future.delayed(const Duration(milliseconds: 500), () {
-      draggingDuringDrag = numberSliderModel.dragging;
+      draggingDuringDrag = numberSliderModel.dragging.value;
       valueDuringDrag = ntConnection.getLastAnnouncedValue('Test/Double Value');
     });
 
@@ -260,7 +261,7 @@ void main() {
     Object? valueDuringDrag;
 
     Future.delayed(const Duration(milliseconds: 500), () {
-      draggingDuringDrag = numberSliderModel.dragging;
+      draggingDuringDrag = numberSliderModel.dragging.value;
       valueDuringDrag = ntConnection.getLastAnnouncedValue('Test/Int Value');
     });
 

--- a/test/widgets/nt_widgets/single-topic/single_color_view_test.dart
+++ b/test/widgets/nt_widgets/single-topic/single_color_view_test.dart
@@ -72,7 +72,7 @@ void main() {
   });
 
   test('Single color view to json', () {
-    NTWidgetModel singleColorViewModel = NTWidgetModel.createDefault(
+    NTWidgetModel singleColorViewModel = SingleTopicNTWidgetModel.createDefault(
       ntConnection: ntConnection,
       preferences: preferences,
       type: 'Single Color View',

--- a/test/widgets/nt_widgets/single-topic/single_color_view_test.dart
+++ b/test/widgets/nt_widgets/single-topic/single_color_view_test.dart
@@ -62,7 +62,7 @@ void main() {
     );
 
     expect(singleColorViewModel.type, 'Single Color View');
-    expect(singleColorViewModel.runtimeType, NTWidgetModel);
+    expect(singleColorViewModel.runtimeType, SingleTopicNTWidgetModel);
     expect(
         singleColorViewModel.getAvailableDisplayTypes(),
         unorderedEquals([

--- a/test/widgets/nt_widgets/single-topic/toggle_button_test.dart
+++ b/test/widgets/nt_widgets/single-topic/toggle_button_test.dart
@@ -50,7 +50,7 @@ void main() {
     );
 
     expect(toggleButtonModel.type, 'Toggle Button');
-    expect(toggleButtonModel.runtimeType, NTWidgetModel);
+    expect(toggleButtonModel.runtimeType, SingleTopicNTWidgetModel);
     expect(
         toggleButtonModel.getAvailableDisplayTypes(),
         unorderedEquals([

--- a/test/widgets/nt_widgets/single-topic/toggle_button_test.dart
+++ b/test/widgets/nt_widgets/single-topic/toggle_button_test.dart
@@ -62,7 +62,7 @@ void main() {
   });
 
   test('Toggle button to json', () {
-    NTWidgetModel toggleButtonModel = NTWidgetModel.createDefault(
+    NTWidgetModel toggleButtonModel = SingleTopicNTWidgetModel.createDefault(
       ntConnection: ntConnection,
       preferences: preferences,
       type: 'Toggle Button',

--- a/test/widgets/nt_widgets/single-topic/toggle_switch_test.dart
+++ b/test/widgets/nt_widgets/single-topic/toggle_switch_test.dart
@@ -62,7 +62,7 @@ void main() {
   });
 
   test('Toggle switch to json', () {
-    NTWidgetModel toggleSwitchModel = NTWidgetModel.createDefault(
+    NTWidgetModel toggleSwitchModel = SingleTopicNTWidgetModel.createDefault(
       ntConnection: ntConnection,
       preferences: preferences,
       type: 'Toggle Switch',

--- a/test/widgets/nt_widgets/single-topic/toggle_switch_test.dart
+++ b/test/widgets/nt_widgets/single-topic/toggle_switch_test.dart
@@ -50,7 +50,7 @@ void main() {
     );
 
     expect(toggleSwitchModel.type, 'Toggle Switch');
-    expect(toggleSwitchModel.runtimeType, NTWidgetModel);
+    expect(toggleSwitchModel.runtimeType, SingleTopicNTWidgetModel);
     expect(
         toggleSwitchModel.getAvailableDisplayTypes(),
         unorderedEquals([

--- a/test/widgets/settings_dialog_test.dart
+++ b/test/widgets/settings_dialog_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flex_seed_scheme/flex_seed_scheme.dart';
 import 'package:flutter_colorpicker/flutter_colorpicker.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -15,42 +14,40 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart'
 import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_toggle_switch.dart';
 import 'package:elastic_dashboard/widgets/settings_dialog.dart';
 import '../test_util.dart';
-import 'settings_dialog_test.mocks.dart';
 
-@GenerateNiceMocks([MockSpec<FakeSettingsMethods>()])
-class FakeSettingsMethods {
-  void changeColor() {}
+class FakeSettingsMethods extends Mock {
+  void changeColor();
 
-  void changeIPAddress() {}
+  void changeIPAddress();
 
-  void changeTeamNumber() {}
+  void changeTeamNumber();
 
-  void changeIPAddressMode() {}
+  void changeIPAddressMode();
 
-  void changeShowGrid() {}
+  void changeShowGrid();
 
-  void changeGridSize() {}
+  void changeGridSize();
 
-  void changeCornerRadius() {}
+  void changeCornerRadius();
 
-  void changeDSAutoResize() {}
+  void changeDSAutoResize();
 
-  void changeRememberWindow() {}
+  void changeRememberWindow();
 
-  void changeLockLayout() {}
+  void changeLockLayout();
 
-  void changeDefaultPeriod() {}
+  void changeDefaultPeriod();
 
-  void changeDefaultGraphPeriod() {}
+  void changeDefaultGraphPeriod();
 
-  void changeThemeVariant() {}
+  void changeThemeVariant();
 }
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   late SharedPreferences preferences;
-  late MockFakeSettingsMethods fakeSettings;
+  late FakeSettingsMethods fakeSettings;
 
   setUpAll(() async {
     SharedPreferences.setMockInitialValues({
@@ -71,7 +68,7 @@ void main() {
 
     preferences = await SharedPreferences.getInstance();
 
-    fakeSettings = MockFakeSettingsMethods();
+    fakeSettings = FakeSettingsMethods();
   });
 
   setUp(() {


### PR DESCRIPTION
Instead of using StreamBuilders which can be slow, constantly create futures and timers, and don't work well with multi-topic widgets, ValueListenableBuilders only get called when the subscription actually updates.

CPU usage has decreased by 10-15%