### PR TITLE
Changed gyro widget to work with doubles

### DIFF
--- a/lib/widgets/nt_widgets/nt_widget.dart
+++ b/lib/widgets/nt_widgets/nt_widget.dart
@@ -1,3 +1,4 @@
+import 'package:elastic_dashboard/widgets/nt_widgets/multi-topic/gyro.dart';
 import 'package:flutter/material.dart';
 
 import 'package:dot_cast/dot_cast.dart';
@@ -186,6 +187,7 @@ class SingleTopicNTWidgetModel extends NTWidgetModel {
           NumberSlider.widgetType,
           VoltageView.widgetType,
           RadialGauge.widgetType,
+          Gyro.widgetType,
           GraphWidget.widgetType,
           MatchTimeWidget.widgetType,
         ];


### PR DESCRIPTION
The gyro widget can now be applied to single-topic double values. It appears as a display option for doubles, and single-topic gyros will also have all of the display options for doubles.