### PR TITLE
Tab Grid Fixes and Cleanup

### DIFF
--- a/lib/widgets/draggable_containers/draggable_widget_container.dart
+++ b/lib/widgets/draggable_containers/draggable_widget_container.dart
@@ -54,29 +54,29 @@ class DraggableWidgetContainer extends StatelessWidget {
           );
         },
         onDragStart: (event) {
-          model.setDragging(true);
-          model.setPreviewVisible(true);
-          model.setDraggingIntoLayout(false);
-          model.setDragStartLocation(model.displayRect);
-          model.setPreviewRect(model.dragStartLocation);
-          model.setValidLocation(
+          model.dragging = true;
+          model.previewVisible = true;
+          model.draggingIntoLayout = false;
+          model.dragStartLocation = model.displayRect;
+          model.previewRect = model.dragStartLocation;
+          model.validLocation =
               updateFunctions?.isValidMoveLocation(model, model.previewRect) ??
-                  true);
+                  true;
 
           updateFunctions?.onDragBegin(model);
 
           controller?.setRect(model.draggingRect);
         },
         onResizeStart: (handle, event) {
-          model.setDragging(true);
-          model.setResizing(true);
-          model.setPreviewVisible(true);
-          model.setDraggingIntoLayout(false);
-          model.setDragStartLocation(model.displayRect);
-          model.setPreviewRect(model.dragStartLocation);
-          model.setValidLocation(
+          model.dragging = true;
+          model.resizing = true;
+          model.previewVisible = true;
+          model.draggingIntoLayout = false;
+          model.dragStartLocation = model.displayRect;
+          model.previewRect = model.dragStartLocation;
+          model.validLocation =
               updateFunctions?.isValidMoveLocation(model, model.previewRect) ??
-                  true);
+                  true;
 
           updateFunctions?.onResizeBegin.call(model);
 
@@ -88,7 +88,7 @@ class DraggableWidgetContainer extends StatelessWidget {
             return;
           }
 
-          model.setCursorGlobalLocation(event.globalPosition);
+          model.cursorGlobalLocation = event.globalPosition;
 
           updateFunctions?.onUpdate(model, result.rect, result);
 
@@ -98,7 +98,7 @@ class DraggableWidgetContainer extends StatelessWidget {
           if (!model.dragging) {
             return;
           }
-          model.setDragging(false);
+          model.dragging = false;
 
           updateFunctions?.onDragEnd(model, model.draggingRect,
               globalPosition: model.cursorGlobalLocation);
@@ -107,7 +107,7 @@ class DraggableWidgetContainer extends StatelessWidget {
         },
         onDragCancel: () {
           Future(() {
-            model.setDragging(false);
+            model.dragging = false;
           });
 
           updateFunctions?.onDragCancel(model);
@@ -118,16 +118,16 @@ class DraggableWidgetContainer extends StatelessWidget {
           if (!model.dragging && !model.resizing) {
             return;
           }
-          model.setDragging(false);
-          model.setResizing(false);
+          model.dragging = false;
+          model.resizing = false;
 
           updateFunctions?.onResizeEnd(model, model.draggingRect);
 
           controller?.setRect(model.draggingRect);
         },
         onResizeCancel: (handle) {
-          model.setDragging(false);
-          model.setResizing(false);
+          model.dragging = false;
+          model.resizing = false;
 
           updateFunctions?.onDragCancel(model);
 

--- a/lib/widgets/draggable_containers/models/layout_container_model.dart
+++ b/lib/widgets/draggable_containers/models/layout_container_model.dart
@@ -2,7 +2,6 @@ import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 
-import 'nt_widget_container_model.dart';
 import 'widget_container_model.dart';
 
 abstract class LayoutContainerModel extends WidgetContainerModel {
@@ -41,5 +40,7 @@ abstract class LayoutContainerModel extends WidgetContainerModel {
 
   bool willAcceptWidget(WidgetContainerModel widget, {Offset? globalPosition});
 
-  void addWidget(NTWidgetContainerModel model);
+  void addWidget(WidgetContainerModel widget);
+
+  void removeWidget(WidgetContainerModel widget);
 }

--- a/lib/widgets/draggable_containers/models/list_layout_model.dart
+++ b/lib/widgets/draggable_containers/models/list_layout_model.dart
@@ -14,9 +14,14 @@ import 'package:elastic_dashboard/widgets/dialog_widgets/dialog_text_input.dart'
 import 'package:elastic_dashboard/widgets/draggable_containers/draggable_widget_container.dart';
 import 'package:elastic_dashboard/widgets/draggable_containers/models/layout_container_model.dart';
 import 'package:elastic_dashboard/widgets/nt_widgets/nt_widget.dart';
-import 'package:elastic_dashboard/widgets/tab_grid.dart';
 import 'nt_widget_container_model.dart';
 import 'widget_container_model.dart';
+
+typedef DragOutFunctions = ({
+  bool Function(WidgetContainerModel widget) dragOutEnd,
+  void Function(
+      WidgetContainerModel widget, Offset globalPosition) dragOutUpdate
+});
 
 class ListLayoutModel extends LayoutContainerModel {
   @override
@@ -26,7 +31,7 @@ class ListLayoutModel extends LayoutContainerModel {
 
   String labelPosition = 'TOP';
 
-  final TabGridModel tabGrid;
+  final DragOutFunctions? dragOutFunctions;
   final NTWidgetContainerModel? Function(
     SharedPreferences preferences,
     Map<String, dynamic> jsonData,
@@ -48,7 +53,7 @@ class ListLayoutModel extends LayoutContainerModel {
     required super.preferences,
     required super.initialPosition,
     required super.title,
-    required this.tabGrid,
+    this.dragOutFunctions,
     required this.onDragCancel,
     this.ntWidgetBuilder,
     List<NTWidgetContainerModel>? children,
@@ -65,7 +70,7 @@ class ListLayoutModel extends LayoutContainerModel {
     required super.jsonData,
     required super.preferences,
     required this.ntWidgetBuilder,
-    required this.tabGrid,
+    this.dragOutFunctions,
     required this.onDragCancel,
     super.enabled,
     super.minWidth,
@@ -332,8 +337,14 @@ class ListLayoutModel extends LayoutContainerModel {
   }
 
   @override
-  void addWidget(NTWidgetContainerModel model) {
-    children.add(model);
+  void addWidget(WidgetContainerModel widget) {
+    children.add(widget as NTWidgetContainerModel);
+    notifyListeners();
+  }
+
+  @override
+  void removeWidget(WidgetContainerModel widget) {
+    children.remove(widget);
     notifyListeners();
   }
 
@@ -491,7 +502,7 @@ class ListLayoutModel extends LayoutContainerModel {
             Offset location = details.globalPosition -
                 Offset(widget.displayRect.width, widget.displayRect.height) / 2;
 
-            tabGrid.layoutDragOutUpdate(widget, location);
+            dragOutFunctions?.dragOutUpdate(widget, location);
           },
           onPanEnd: (details) {
             if (preferences.getBool(PrefKeys.layoutLocked) ??
@@ -500,26 +511,10 @@ class ListLayoutModel extends LayoutContainerModel {
             }
             Future(() => draggable = true);
 
-            int? gridSize = preferences.getInt(PrefKeys.gridSize);
-
-            Rect previewLocation = Rect.fromLTWH(
-              DraggableWidgetContainer.snapToGrid(
-                  widget.draggingRect.left, gridSize),
-              DraggableWidgetContainer.snapToGrid(
-                  widget.draggingRect.top, gridSize),
-              widget.displayRect.width,
-              widget.displayRect.height,
-            );
-
-            if ((tabGrid.isValidMoveLocation(widget, previewLocation) ||
-                    tabGrid
-                        .isValidLayoutLocation(widget.cursorGlobalLocation)) &&
-                tabGrid.isDraggingInContainer()) {
+            if (dragOutFunctions?.dragOutEnd(widget) ?? false) {
               children.remove(widget);
               notifyListeners();
             }
-
-            tabGrid.layoutDragOutEnd(widget);
           },
           onPanCancel: () {
             if (preferences.getBool(PrefKeys.layoutLocked) ??

--- a/lib/widgets/draggable_containers/models/list_layout_model.dart
+++ b/lib/widgets/draggable_containers/models/list_layout_model.dart
@@ -160,12 +160,12 @@ class ListLayoutModel extends LayoutContainerModel {
   }
 
   @override
-  void setEnabled(bool enabled) {
+  set enabled(bool enabled) {
     for (var container in children) {
-      container.setEnabled(enabled);
+      container.enabled = enabled;
     }
 
-    super.setEnabled(enabled);
+    super.enabled = enabled;
   }
 
   @override
@@ -300,7 +300,7 @@ class ListLayoutModel extends LayoutContainerModel {
       DialogTextInput(
         onSubmit: (value) {
           setState(() {
-            container.setTitle(value);
+            container.title = value;
 
             notifyListeners();
           });
@@ -478,7 +478,7 @@ class ListLayoutModel extends LayoutContainerModel {
                 onDragCancel?.call(this);
               }
 
-              setDraggable(false);
+              draggable = false;
             });
           },
           onPanUpdate: (details) {
@@ -498,7 +498,7 @@ class ListLayoutModel extends LayoutContainerModel {
                 Defaults.layoutLocked) {
               return;
             }
-            Future(() => setDraggable(true));
+            Future(() => draggable = true);
 
             int? gridSize = preferences.getInt(PrefKeys.gridSize);
 
@@ -526,12 +526,13 @@ class ListLayoutModel extends LayoutContainerModel {
                 Defaults.layoutLocked) {
               return;
             }
+
             Future(() {
               if (dragging || resizing) {
                 onDragCancel?.call(this);
               }
 
-              setDraggable(true);
+              draggable = true;
             });
           },
           child: Padding(

--- a/lib/widgets/draggable_containers/models/widget_container_model.dart
+++ b/lib/widgets/draggable_containers/models/widget_container_model.dart
@@ -12,67 +12,165 @@ abstract class WidgetContainerModel extends ChangeNotifier {
   final Key key = UniqueKey();
   final SharedPreferences preferences;
 
-  String? title;
+  String? _title;
 
-  late bool draggable =
+  String? get title => _title;
+
+  set title(String? value) {
+    _title = value;
+    notifyListeners();
+  }
+
+  late bool _draggable =
       !(preferences.getBool(PrefKeys.layoutLocked) ?? Defaults.layoutLocked);
+
+  bool get draggable => _draggable;
+
+  set draggable(bool value) {
+    _draggable = value;
+    notifyListeners();
+  }
+
   bool _disposed = false;
   bool _forceDispose = false;
 
-  late Rect draggingRect = Rect.fromLTWH(
+  late Rect _draggingRect = Rect.fromLTWH(
       0,
       0,
       (preferences.getInt(PrefKeys.gridSize) ?? Defaults.gridSize).toDouble(),
       (preferences.getInt(PrefKeys.gridSize) ?? Defaults.gridSize).toDouble());
 
-  Offset cursorGlobalLocation = const Offset(double.nan, double.nan);
+  Rect get draggingRect => _draggingRect;
 
-  late Rect displayRect = Rect.fromLTWH(
+  set draggingRect(Rect value) {
+    _draggingRect = value;
+    notifyListeners();
+  }
+
+  Offset _cursorGlobalLocation = const Offset(double.nan, double.nan);
+
+  Offset get cursorGlobalLocation => _cursorGlobalLocation;
+
+  set cursorGlobalLocation(Offset value) {
+    _cursorGlobalLocation = value;
+    notifyListeners();
+  }
+
+  late Rect _displayRect = Rect.fromLTWH(
       0,
       0,
       (preferences.getInt(PrefKeys.gridSize) ?? Defaults.gridSize).toDouble(),
       (preferences.getInt(PrefKeys.gridSize) ?? Defaults.gridSize).toDouble());
 
-  late Rect previewRect = Rect.fromLTWH(
+  Rect get displayRect => _displayRect;
+
+  set displayRect(Rect value) {
+    _displayRect = value;
+    notifyListeners();
+  }
+
+  late Rect _previewRect = Rect.fromLTWH(
       0,
       0,
       (preferences.getInt(PrefKeys.gridSize) ?? Defaults.gridSize).toDouble(),
       (preferences.getInt(PrefKeys.gridSize) ?? Defaults.gridSize).toDouble());
 
-  bool enabled = false;
-  bool dragging = false;
-  bool resizing = false;
-  bool draggingIntoLayout = false;
-  bool previewVisible = false;
-  bool validLocation = true;
+  Rect get previewRect => _previewRect;
+
+  set previewRect(Rect value) {
+    _previewRect = value;
+    notifyListeners();
+  }
+
+  bool _enabled = false;
+
+  bool get enabled => _enabled;
+
+  set enabled(bool value) {
+    _enabled = value;
+    notifyListeners();
+  }
+
+  bool _dragging = false;
+
+  bool get dragging => _dragging;
+
+  set dragging(bool value) {
+    _dragging = value;
+    notifyListeners();
+  }
+
+  bool _resizing = false;
+
+  bool get resizing => _resizing;
+
+  set resizing(bool value) {
+    _resizing = value;
+    notifyListeners();
+  }
+
+  bool _draggingIntoLayout = false;
+
+  bool get draggingIntoLayout => _draggingIntoLayout;
+
+  set draggingIntoLayout(bool value) {
+    _draggingIntoLayout = value;
+    notifyListeners();
+  }
+
+  bool _previewVisible = false;
+
+  bool get previewVisible => _previewVisible;
+
+  set previewVisible(bool value) {
+    _previewVisible = value;
+    notifyListeners();
+  }
+
+  bool _validLocation = true;
+
+  bool get validLocation => _validLocation;
+
+  set validLocation(bool value) {
+    _validLocation = value;
+    notifyListeners();
+  }
 
   late double minWidth =
       (preferences.getInt(PrefKeys.gridSize) ?? Defaults.gridSize).toDouble();
   late double minHeight =
       (preferences.getInt(PrefKeys.gridSize) ?? Defaults.gridSize).toDouble();
 
-  late Rect dragStartLocation;
+  late Rect _dragStartLocation;
+
+  Rect get dragStartLocation => _dragStartLocation;
+
+  set dragStartLocation(Rect value) {
+    _dragStartLocation = value;
+    notifyListeners();
+  }
 
   WidgetContainerModel({
     required this.preferences,
     required Rect initialPosition,
-    required this.title,
-    this.enabled = false,
+    required String? title,
+    bool enabled = false,
     this.minWidth = 128.0,
     this.minHeight = 128.0,
-  }) {
-    displayRect = initialPosition;
+  })  : _title = title,
+        _enabled = enabled {
+    _displayRect = initialPosition;
     init();
   }
 
   WidgetContainerModel.fromJson({
     required Map<String, dynamic> jsonData,
     required this.preferences,
-    this.enabled = false,
+    bool enabled = false,
     this.minWidth = 128.0,
     this.minHeight = 128.0,
     Function(String errorMessage)? onJsonLoadingWarning,
-  }) {
+  }) : _enabled = enabled {
     fromJson(jsonData);
     init();
   }
@@ -159,72 +257,6 @@ abstract class WidgetContainerModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void setTitle(String title) {
-    this.title = title;
-
-    notifyListeners();
-  }
-
-  void setDraggable(bool draggable) {
-    this.draggable = draggable;
-    notifyListeners();
-  }
-
-  void setDragging(bool dragging) {
-    this.dragging = dragging;
-    notifyListeners();
-  }
-
-  void setResizing(bool resizing) {
-    this.resizing = resizing;
-    notifyListeners();
-  }
-
-  void setPreviewVisible(bool previewVisible) {
-    this.previewVisible = previewVisible;
-    notifyListeners();
-  }
-
-  void setValidLocation(bool validLocation) {
-    this.validLocation = validLocation;
-    notifyListeners();
-  }
-
-  void setDraggingIntoLayout(bool draggingIntoLayout) {
-    this.draggingIntoLayout = draggingIntoLayout;
-    notifyListeners();
-  }
-
-  void setEnabled(bool enabled) {
-    this.enabled = enabled;
-    notifyListeners();
-  }
-
-  void setDisplayRect(Rect displayRect) {
-    this.displayRect = displayRect;
-    notifyListeners();
-  }
-
-  void setDraggingRect(Rect draggingRect) {
-    this.draggingRect = draggingRect;
-    notifyListeners();
-  }
-
-  void setPreviewRect(Rect previewRect) {
-    this.previewRect = previewRect;
-    notifyListeners();
-  }
-
-  void setDragStartLocation(Rect dragStartLocation) {
-    this.dragStartLocation = dragStartLocation;
-    notifyListeners();
-  }
-
-  void setCursorGlobalLocation(Offset globalLocation) {
-    cursorGlobalLocation = globalLocation;
-    notifyListeners();
-  }
-
   void showEditProperties(BuildContext context) {
     showDialog(
       context: context,
@@ -261,7 +293,7 @@ abstract class WidgetContainerModel extends ChangeNotifier {
       const SizedBox(height: 5),
       DialogTextInput(
         onSubmit: (value) {
-          setTitle(value);
+          title = value;
         },
         label: 'Title',
         initialText: title,

--- a/lib/widgets/tab_grid.dart
+++ b/lib/widgets/tab_grid.dart
@@ -54,6 +54,10 @@ class TabGridModel extends ChangeNotifier {
     if (jsonData['layouts'] != null) {
       loadLayoutsFromJson(jsonData, onJsonLoadingWarning: onJsonLoadingWarning);
     }
+
+    for (WidgetContainerModel model in _widgetModels) {
+      model.addListener(notifyListeners);
+    }
   }
 
   void loadContainersFromJson(Map<String, dynamic> jsonData,
@@ -201,16 +205,16 @@ class TabGridModel extends ChangeNotifier {
 
   void onWidgetResizeEnd(WidgetContainerModel model) {
     if (model.validLocation) {
-      model.setDraggingRect(model.previewRect);
+      model.draggingRect = model.previewRect;
     } else {
-      model.setDraggingRect(model.dragStartLocation);
+      model.draggingRect = model.dragStartLocation;
     }
 
-    model.setDisplayRect(model.draggingRect);
+    model.displayRect = model.draggingRect;
 
-    model.setPreviewRect(model.draggingRect);
-    model.setPreviewVisible(false);
-    model.setValidLocation(true);
+    model.previewRect = model.draggingRect;
+    model.previewVisible = false;
+    model.validLocation = true;
 
     if (model is NTWidgetContainerModel &&
         model.childModel is FieldWidgetModel) {
@@ -222,16 +226,16 @@ class TabGridModel extends ChangeNotifier {
 
   void onWidgetDragEnd(WidgetContainerModel model) {
     if (model.validLocation) {
-      model.setDraggingRect(model.previewRect);
+      model.draggingRect = model.previewRect;
     } else {
-      model.setDraggingRect(model.dragStartLocation);
+      model.draggingRect = model.dragStartLocation;
     }
 
-    model.setDisplayRect(model.draggingRect);
+    model.displayRect = model.draggingRect;
 
-    model.setPreviewRect(model.draggingRect);
-    model.setPreviewVisible(false);
-    model.setValidLocation(true);
+    model.previewRect = model.draggingRect;
+    model.previewVisible = false;
+    model.validLocation = true;
 
     model.disposeModel(deleting: false);
   }
@@ -241,16 +245,16 @@ class TabGridModel extends ChangeNotifier {
       return;
     }
 
-    model.setDraggingRect(model.dragStartLocation);
-    model.setDisplayRect(model.draggingRect);
-    model.setPreviewRect(model.draggingRect);
+    model.draggingRect = model.dragStartLocation;
+    model.displayRect = model.draggingRect;
+    model.previewRect = model.draggingRect;
 
-    model.setPreviewVisible(false);
-    model.setValidLocation(true);
+    model.previewVisible = false;
+    model.validLocation = true;
 
-    model.setDragging(false);
-    model.setResizing(false);
-    model.setDraggingIntoLayout(false);
+    model.dragging = false;
+    model.resizing = false;
+    model.draggingIntoLayout = false;
 
     model.disposeModel();
   }
@@ -333,37 +337,31 @@ class TabGridModel extends ChangeNotifier {
     Rect preview =
         Rect.fromLTWH(previewX, previewY, previewWidth, previewHeight);
 
-    model.setDraggingRect(constrainedRect);
-    model.setPreviewRect(preview);
-    model.setPreviewVisible(true);
+    model.draggingRect = constrainedRect;
+    model.previewRect = preview;
+    model.previewVisible = true;
 
     bool validLocation = isValidMoveLocation(model, preview);
 
     if (validLocation) {
-      model.setValidLocation(true);
-
-      model.setDraggingIntoLayout(false);
+      model.validLocation = true;
+      model.draggingIntoLayout = false;
     } else {
       validLocation = isValidLayoutLocation(model.cursorGlobalLocation) &&
           model is! LayoutContainerModel &&
           !model.resizing;
 
-      model.setDraggingIntoLayout(validLocation);
-
-      model.setValidLocation(validLocation);
+      model.draggingIntoLayout = validLocation;
+      model.validLocation = validLocation;
     }
   }
 
   void _ntContainerOnUpdate(
       WidgetContainerModel widget, Rect newRect, TransformResult result) {
     onWidgetUpdate(widget, newRect, result);
-
-    refresh();
   }
 
-  void _ntContainerOnDragBegin(WidgetContainerModel widget) {
-    refresh();
-  }
+  void _ntContainerOnDragBegin(WidgetContainerModel widget) {}
 
   void _ntContainerOnDragEnd(WidgetContainerModel model, Rect releaseRect,
       {Offset? globalPosition}) {
@@ -377,60 +375,42 @@ class TabGridModel extends ChangeNotifier {
       if (layoutModel != null) {
         layoutModel.addWidget(ntContainer);
         _widgetModels.remove(ntContainer);
+        ntContainer.removeListener(notifyListeners);
       }
     }
-    refresh();
   }
 
   void _ntContainerOnDragCancel(WidgetContainerModel widget) {
     onWidgetDragCancel(widget);
-
-    refresh();
   }
 
-  void _ntContainerOnResizeBegin(WidgetContainerModel widget) {
-    refresh();
-  }
+  void _ntContainerOnResizeBegin(WidgetContainerModel widget) {}
 
   void _ntContainerOnResizeEnd(WidgetContainerModel widget, Rect releaseRect) {
     onWidgetResizeEnd(widget);
-
-    refresh();
   }
 
   void _layoutContainerOnUpdate(
       WidgetContainerModel widget, Rect newRect, TransformResult result) {
     onWidgetUpdate(widget, newRect, result);
-
-    refresh();
   }
 
-  void _layoutContainerOnDragBegin(WidgetContainerModel widget) {
-    refresh();
-  }
+  void _layoutContainerOnDragBegin(WidgetContainerModel widget) {}
 
   void _layoutContainerOnDragEnd(WidgetContainerModel widget, Rect releaseRect,
       {Offset? globalPosition}) {
     onWidgetDragEnd(widget);
-
-    refresh();
   }
 
   void _layoutContainerOnDragCancel(WidgetContainerModel widget) {
     onWidgetDragCancel(widget);
-
-    refresh();
   }
 
-  void _layoutContainerOnResizeBegin(WidgetContainerModel widget) {
-    refresh();
-  }
+  void _layoutContainerOnResizeBegin(WidgetContainerModel widget) {}
 
   void _layoutContainerOnResizeEnd(
       WidgetContainerModel widget, Rect releaseRect) {
     onWidgetResizeEnd(widget);
-
-    refresh();
   }
 
   void layoutDragOutEnd(WidgetContainerModel widget) {
@@ -441,47 +421,39 @@ class TabGridModel extends ChangeNotifier {
 
   void layoutDragOutUpdate(WidgetContainerModel model, Offset globalPosition) {
     Offset localPosition = getLocalPosition(globalPosition);
-    model.setDraggingRect(
-      Rect.fromLTWH(
-        localPosition.dx,
-        localPosition.dy,
-        model.draggingRect.width,
-        model.draggingRect.height,
-      ),
+    model.draggingRect = Rect.fromLTWH(
+      localPosition.dx,
+      localPosition.dy,
+      model.draggingRect.width,
+      model.draggingRect.height,
     );
     _containerDraggingIn = MapEntry(model, globalPosition);
-    refresh();
+    notifyListeners();
   }
 
   void onNTConnect() {
     for (WidgetContainerModel model in _widgetModels) {
-      model.setEnabled(true);
+      model.enabled = true;
     }
-
-    refresh();
   }
 
   void onNTDisconnect() {
     for (WidgetContainerModel container in _widgetModels) {
-      container.setEnabled(false);
+      container.enabled = false;
     }
-
-    refresh();
   }
 
   void addDragInWidget(WidgetContainerModel widget, Offset globalPosition) {
     Offset localPosition = getLocalPosition(globalPosition);
-    widget.setDraggingRect(
-      Rect.fromLTWH(
-        localPosition.dx,
-        localPosition.dy,
-        widget.draggingRect.width,
-        widget.draggingRect.height,
-      ),
+    widget.draggingRect = Rect.fromLTWH(
+      localPosition.dx,
+      localPosition.dy,
+      widget.draggingRect.width,
+      widget.draggingRect.height,
     );
 
     _containerDraggingIn = MapEntry(widget, globalPosition);
-    refresh();
+    notifyListeners();
   }
 
   void placeDragInWidget(WidgetContainerModel widget,
@@ -505,10 +477,10 @@ class TabGridModel extends ChangeNotifier {
     double height = widget.displayRect.height;
 
     Rect previewLocation = Rect.fromLTWH(previewX, previewY, width, height);
-    widget.setPreviewRect(previewLocation);
+    widget.previewRect = previewLocation;
 
     widget.tryCast<NTWidgetContainerModel>()?.updateMinimumSize();
-    widget.setEnabled(ntConnection.isNT4Connected);
+    widget.enabled = ntConnection.isNT4Connected;
 
     // If dragging into layout
     if (widget is NTWidgetContainerModel &&
@@ -518,6 +490,15 @@ class TabGridModel extends ChangeNotifier {
 
       if (layoutContainer.willAcceptWidget(widget)) {
         layoutContainer.addWidget(widget);
+      } else {
+        widget.disposeModel(deleting: !fromLayout);
+        if (!fromLayout) {
+          widget.unSubscribe();
+          widget.forceDispose();
+        }
+
+        notifyListeners();
+        return;
       }
     } else if (!isValidMoveLocation(widget, previewLocation)) {
       _containerDraggingIn = null;
@@ -528,7 +509,7 @@ class TabGridModel extends ChangeNotifier {
         widget.forceDispose();
       }
 
-      refresh();
+      notifyListeners();
       return;
     } else {
       widget.displayRect = previewLocation;
@@ -540,7 +521,7 @@ class TabGridModel extends ChangeNotifier {
     _containerDraggingIn = null;
 
     widget.disposeModel();
-    refresh();
+    notifyListeners();
   }
 
   ListLayoutModel createListLayout(
@@ -566,6 +547,8 @@ class TabGridModel extends ChangeNotifier {
 
   void addWidget(WidgetContainerModel widget) {
     _widgetModels.add(widget);
+    widget.addListener(notifyListeners);
+    notifyListeners();
   }
 
   void addWidgetFromTabJson(Map<String, dynamic> widgetData) {
@@ -609,7 +592,7 @@ class TabGridModel extends ChangeNotifier {
     if (widgetData['layout']) {
       switch (widgetData['type']) {
         case 'List Layout':
-          _widgetModels.add(
+          addWidget(
             ListLayoutModel.fromJson(
               preferences: preferences,
               jsonData: widgetData,
@@ -631,7 +614,7 @@ class TabGridModel extends ChangeNotifier {
           break;
       }
     } else {
-      _widgetModels.add(
+      addWidget(
         NTWidgetContainerModel.fromJson(
           ntConnection: ntConnection,
           preferences: preferences,
@@ -640,27 +623,27 @@ class TabGridModel extends ChangeNotifier {
         ),
       );
     }
-
-    refresh();
   }
 
   void removeWidget(WidgetContainerModel widget) {
+    widget.removeListener(notifyListeners);
     widget.disposeModel(deleting: true);
     widget.unSubscribe();
     widget.forceDispose();
     _widgetModels.remove(widget);
-    refresh();
+    notifyListeners();
   }
 
   @visibleForTesting
   void clearWidgets() {
     for (WidgetContainerModel container in _widgetModels) {
+      container.removeListener(notifyListeners);
       container.disposeModel(deleting: true);
       container.unSubscribe();
       container.forceDispose();
     }
     _widgetModels.clear();
-    refresh();
+    notifyListeners();
   }
 
   void confirmClearWidgets(BuildContext context) {
@@ -696,18 +679,19 @@ class TabGridModel extends ChangeNotifier {
 
   void lockLayout() {
     for (WidgetContainerModel container in _widgetModels) {
-      container.setDraggable(false);
+      container.draggable = false;
     }
   }
 
   void unlockLayout() {
     for (WidgetContainerModel container in _widgetModels) {
-      container.setDraggable(true);
+      container.draggable = true;
     }
   }
 
   void onDestroy() {
     for (WidgetContainerModel container in _widgetModels) {
+      container.removeListener(notifyListeners);
       container.disposeModel(deleting: true);
       container.unSubscribe();
       container.forceDispose();
@@ -719,7 +703,7 @@ class TabGridModel extends ChangeNotifier {
     for (WidgetContainerModel widget in _widgetModels) {
       widget.updateGridSize(oldSize, newSize);
     }
-    refresh();
+    notifyListeners();
   }
 
   void refreshAllContainers() {
@@ -728,10 +712,6 @@ class TabGridModel extends ChangeNotifier {
         widget.notifyListeners();
       }
     });
-  }
-
-  void refresh() {
-    notifyListeners();
   }
 }
 
@@ -1048,8 +1028,7 @@ class TabGrid extends StatelessWidget {
       WidgetContainerModel copiedWidget =
           createWidgetFromJson(grid, widgetJson);
 
-      grid._widgetModels.add(copiedWidget);
-      grid.refresh();
+      grid.addWidget(copiedWidget);
     }
   }
 

--- a/lib/widgets/tab_grid.dart
+++ b/lib/widgets/tab_grid.dart
@@ -100,7 +100,10 @@ class TabGridModel extends ChangeNotifier {
               onJsonLoadingWarning: onJsonLoadingWarning,
             ),
             enabled: ntConnection.isNT4Connected,
-            tabGrid: this,
+            dragOutFunctions: (
+              dragOutUpdate: layoutDragOutUpdate,
+              dragOutEnd: layoutDragOutEnd,
+            ),
             onDragCancel: _layoutContainerOnDragCancel,
             minWidth: 128.0 * 2,
             minHeight: 128.0 * 2,
@@ -413,10 +416,11 @@ class TabGridModel extends ChangeNotifier {
     onWidgetResizeEnd(widget);
   }
 
-  void layoutDragOutEnd(WidgetContainerModel widget) {
+  bool layoutDragOutEnd(WidgetContainerModel widget) {
     if (widget is NTWidgetContainerModel) {
-      placeDragInWidget(widget, true);
+      return placeDragInWidget(widget, true);
     }
+    return false;
   }
 
   void layoutDragOutUpdate(WidgetContainerModel model, Offset globalPosition) {
@@ -456,10 +460,10 @@ class TabGridModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void placeDragInWidget(WidgetContainerModel widget,
+  bool placeDragInWidget(WidgetContainerModel widget,
       [bool fromLayout = false]) {
     if (_containerDraggingIn == null) {
-      return;
+      return false;
     }
 
     Offset globalPosition = _containerDraggingIn!.value;
@@ -498,7 +502,7 @@ class TabGridModel extends ChangeNotifier {
         }
 
         notifyListeners();
-        return;
+        return false;
       }
     } else if (!isValidMoveLocation(widget, previewLocation)) {
       _containerDraggingIn = null;
@@ -510,7 +514,7 @@ class TabGridModel extends ChangeNotifier {
       }
 
       notifyListeners();
-      return;
+      return false;
     } else {
       widget.displayRect = previewLocation;
       widget.draggingRect = Rect.fromLTWH(previewX, previewY, width, height);
@@ -522,6 +526,8 @@ class TabGridModel extends ChangeNotifier {
 
     widget.disposeModel();
     notifyListeners();
+
+    return true;
   }
 
   ListLayoutModel createListLayout(
@@ -540,7 +546,10 @@ class TabGridModel extends ChangeNotifier {
       children: children,
       minWidth: 128.0,
       minHeight: 128.0,
-      tabGrid: this,
+      dragOutFunctions: (
+        dragOutUpdate: layoutDragOutUpdate,
+        dragOutEnd: layoutDragOutEnd,
+      ),
       onDragCancel: _layoutContainerOnDragCancel,
     );
   }
@@ -605,7 +614,10 @@ class TabGridModel extends ChangeNotifier {
                 onJsonLoadingWarning: onJsonLoadingWarning,
               ),
               enabled: ntConnection.isNT4Connected,
-              tabGrid: this,
+              dragOutFunctions: (
+                dragOutUpdate: layoutDragOutUpdate,
+                dragOutEnd: layoutDragOutEnd,
+              ),
               onDragCancel: _layoutContainerOnDragCancel,
               minWidth: 128.0 * 2,
               minHeight: 128.0 * 2,
@@ -1038,7 +1050,10 @@ class TabGrid extends StatelessWidget {
       return ListLayoutModel.fromJson(
         preferences: grid.preferences,
         jsonData: json,
-        tabGrid: grid,
+        dragOutFunctions: (
+          dragOutUpdate: grid.layoutDragOutUpdate,
+          dragOutEnd: grid.layoutDragOutEnd,
+        ),
         ntWidgetBuilder: (preferences, jsonData, enabled,
                 {onJsonLoadingWarning}) =>
             NTWidgetContainerModel.fromJson(


### PR DESCRIPTION
- Remove refresh() method
- Listen to state changes for each container model
- Use setter and getter methods for state notifying fields
- Remove tab grid field from list layouts