### PR TITLE
Fix list layout creation for unregistered sendable types

### DIFF
--- a/.github/workflows/elastic-ci.yml
+++ b/.github/workflows/elastic-ci.yml
@@ -44,7 +44,7 @@ jobs:
         run: dart run import_sorter:main --exit-if-changed
 
       - name: Analyze project source
-        run: flutter analyze --no-fatal-infos --no-fatal-warnings
+        run: flutter analyze --no-fatal-infos
   test:
     name: "Run Tests"
     runs-on: ubuntu-22.04

--- a/lib/services/nt_widget_builder.dart
+++ b/lib/services/nt_widget_builder.dart
@@ -484,10 +484,13 @@ class NTWidgetBuilder {
     return DraggableWidgetContainer.snapToGrid(_normalSize, gridSize);
   }
 
-  static bool isRegistered(String name) =>
-      (_modelNameBuildMap.containsKey(name) &&
-          _modelJsonBuildMap.containsKey(name)) ||
-      _widgetNameBuildMap.containsKey(name);
+  static bool isRegistered(String name) {
+    ensureInitialized();
+
+    return (_modelNameBuildMap.containsKey(name) &&
+            _modelJsonBuildMap.containsKey(name)) ||
+        _widgetNameBuildMap.containsKey(name);
+  }
 
   static void
       register<ModelType extends NTWidgetModel, WidgetType extends NTWidget>({

--- a/lib/services/nt_widget_builder.dart
+++ b/lib/services/nt_widget_builder.dart
@@ -484,6 +484,11 @@ class NTWidgetBuilder {
     return DraggableWidgetContainer.snapToGrid(_normalSize, gridSize);
   }
 
+  static bool isRegistered(String name) =>
+      (_modelNameBuildMap.containsKey(name) &&
+          _modelJsonBuildMap.containsKey(name)) ||
+      _widgetNameBuildMap.containsKey(name);
+
   static void
       register<ModelType extends NTWidgetModel, WidgetType extends NTWidget>({
     required String name,

--- a/lib/widgets/network_tree/networktables_tree.dart
+++ b/lib/widgets/network_tree/networktables_tree.dart
@@ -212,7 +212,7 @@ class _NetworkTableTreeState extends State<NetworkTableTree> {
   }
 }
 
-class TreeTile extends StatelessWidget {
+class TreeTile extends StatefulWidget {
   final SharedPreferences preferences;
   final TreeEntry<NetworkTableTreeRow> entry;
   final VoidCallback onTap;
@@ -223,9 +223,7 @@ class TreeTile extends StatelessWidget {
       onDragUpdate;
   final Function(WidgetContainerModel widget)? onDragEnd;
 
-  WidgetContainerModel? draggingWidget;
-
-  TreeTile({
+  const TreeTile({
     super.key,
     required this.preferences,
     required this.entry,
@@ -234,6 +232,23 @@ class TreeTile extends StatelessWidget {
     this.onDragUpdate,
     this.onDragEnd,
   });
+
+  @override
+  State<TreeTile> createState() => _TreeTileState();
+}
+
+class _TreeTileState extends State<TreeTile> {
+  WidgetContainerModel? draggingWidget;
+  bool dragging = false;
+
+  @override
+  void dispose() {
+    draggingWidget?.unSubscribe();
+    draggingWidget?.disposeModel(deleting: true);
+    draggingWidget?.forceDispose();
+
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -245,7 +260,7 @@ class TreeTile extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           InkWell(
-            onTap: onTap,
+            onTap: widget.onTap,
             child: GestureDetector(
               supportedDevices: PointerDeviceKind.values
                   .whereNot((element) => element == PointerDeviceKind.trackpad)
@@ -254,9 +269,17 @@ class TreeTile extends StatelessWidget {
                 if (draggingWidget != null) {
                   return;
                 }
+                dragging = true;
 
-                draggingWidget = await entry.node.toWidgetContainerModel(
-                    listLayoutBuilder: listLayoutBuilder);
+                draggingWidget = await widget.entry.node.toWidgetContainerModel(
+                    listLayoutBuilder: widget.listLayoutBuilder);
+                if (!dragging) {
+                  draggingWidget?.unSubscribe();
+                  draggingWidget?.disposeModel(deleting: true);
+                  draggingWidget?.forceDispose();
+
+                  draggingWidget = null;
+                }
               },
               onPanUpdate: (details) {
                 if (draggingWidget == null) {
@@ -272,37 +295,45 @@ class TreeTile extends StatelessWidget {
                         ) /
                         2;
 
-                onDragUpdate?.call(position, draggingWidget!);
+                widget.onDragUpdate?.call(position, draggingWidget!);
               },
               onPanEnd: (details) {
                 if (draggingWidget == null) {
+                  dragging = false;
                   return;
                 }
 
-                onDragEnd?.call(draggingWidget!);
+                widget.onDragEnd?.call(draggingWidget!);
 
                 draggingWidget = null;
+
+                dragging = false;
               },
               child: Padding(
-                padding: EdgeInsetsDirectional.only(start: entry.level * 16.0),
+                padding: EdgeInsetsDirectional.only(
+                    start: widget.entry.level * 16.0),
                 child: Column(
                   children: [
                     ListTile(
                       dense: true,
                       contentPadding: const EdgeInsets.only(right: 20.0),
-                      leading: (entry.hasChildren ||
-                              entry.node.containsOnlyMetadata())
+                      leading: (widget.entry.hasChildren ||
+                              widget.entry.node.containsOnlyMetadata())
                           ? FolderButton(
                               openedIcon: const Icon(Icons.arrow_drop_down),
                               closedIcon: const Icon(Icons.arrow_right),
                               iconSize: 24,
-                              isOpen: entry.hasChildren && entry.isExpanded,
-                              onPressed: entry.hasChildren ? onTap : null,
+                              isOpen: widget.entry.hasChildren &&
+                                  widget.entry.isExpanded,
+                              onPressed: widget.entry.hasChildren
+                                  ? widget.onTap
+                                  : null,
                             )
                           : const SizedBox(width: 8.0),
-                      title: Text(entry.node.rowName),
-                      trailing: (entry.node.ntTopic != null)
-                          ? Text(entry.node.ntTopic!.type, style: trailingStyle)
+                      title: Text(widget.entry.node.rowName),
+                      trailing: (widget.entry.node.ntTopic != null)
+                          ? Text(widget.entry.node.ntTopic!.type,
+                              style: trailingStyle)
                           : null,
                     ),
                   ],

--- a/lib/widgets/tab_grid.dart
+++ b/lib/widgets/tab_grid.dart
@@ -576,7 +576,7 @@ class TabGridModel extends ChangeNotifier {
       tryCast(widgetData['height']) ?? 0.0,
     );
     // If the widget is already in the tab, don't add it
-    if (!widgetData['layout']) {
+    if (!(widgetData.containsKey('layout') && widgetData['layout'])) {
       for (NTWidgetContainerModel container
           in _widgetModels.whereType<NTWidgetContainerModel>()) {
         String? title = container.title;
@@ -606,7 +606,7 @@ class TabGridModel extends ChangeNotifier {
       }
     }
 
-    if (widgetData['layout']) {
+    if (widgetData.containsKey('layout') && widgetData['layout']) {
       switch (widgetData['type']) {
         case 'List Layout':
           _widgetModels.add(

--- a/test/pages/dashboard_page_test.dart
+++ b/test/pages/dashboard_page_test.dart
@@ -270,7 +270,6 @@ void main() {
 
   testWidgets('Add widget dialog (widgets)', (widgetTester) async {
     FlutterError.onError = ignoreOverflowErrors;
-    createMockOnlineNT4();
 
     await widgetTester.pumpWidget(
       MaterialApp(
@@ -387,6 +386,147 @@ void main() {
     await widgetTester.pumpAndSettle();
 
     expect(listLayoutContainer, findsOneWidget);
+  });
+
+  testWidgets('Add widget dialog (list layout sub-table)',
+      (widgetTester) async {
+    FlutterError.onError = ignoreOverflowErrors;
+
+    await widgetTester.pumpWidget(
+      MaterialApp(
+        home: DashboardPage(
+          ntConnection: createMockOnlineNT4(
+            virtualTopics: [
+              NT4Topic(
+                name: '/Non-Typed/Value 1',
+                type: NT4TypeStr.kInt,
+                properties: {},
+              ),
+              NT4Topic(
+                name: '/Non-Typed/Value 2',
+                type: NT4TypeStr.kInt,
+                properties: {},
+              ),
+              NT4Topic(
+                name: '/Non-Typed/Value 3',
+                type: NT4TypeStr.kInt,
+                properties: {},
+              ),
+            ],
+          ),
+          preferences: preferences,
+          version: '0.0.0.0',
+          updateChecker: createMockUpdateChecker(),
+        ),
+      ),
+    );
+
+    await widgetTester.pumpAndSettle();
+
+    final addWidget = find.widgetWithText(MenuItemButton, 'Add Widget');
+
+    expect(addWidget, findsOneWidget);
+    expect(find.widgetWithText(DraggableDialog, 'Add Widget'), findsNothing);
+
+    MenuItemButton addWidgetButton =
+        addWidget.evaluate().first.widget as MenuItemButton;
+
+    addWidgetButton.onPressed?.call();
+
+    await widgetTester.pumpAndSettle();
+
+    expect(find.widgetWithText(DraggableDialog, 'Add Widget'), findsOneWidget);
+
+    final nonTypedTile = find.widgetWithText(TreeTile, 'Non-Typed');
+
+    expect(nonTypedTile, findsOneWidget);
+
+    final nonTypedContainer = find.widgetWithText(WidgetContainer, 'Non-Typed');
+    expect(nonTypedContainer, findsNothing);
+
+    await widgetTester.drag(
+      nonTypedTile,
+      const Offset(250, 0),
+      kind: PointerDeviceKind.mouse,
+    );
+    await widgetTester.pumpAndSettle();
+
+    expect(nonTypedContainer, findsOneWidget);
+  });
+
+  testWidgets('Add widget dialog (unregistered sendable)',
+      (widgetTester) async {
+    FlutterError.onError = ignoreOverflowErrors;
+
+    await widgetTester.pumpWidget(
+      MaterialApp(
+        home: DashboardPage(
+          ntConnection: createMockOnlineNT4(
+            virtualTopics: [
+              NT4Topic(
+                name: '/Non-Registered/.type',
+                type: NT4TypeStr.kString,
+                properties: {},
+              ),
+              NT4Topic(
+                name: '/Non-Registered/Value 1',
+                type: NT4TypeStr.kInt,
+                properties: {},
+              ),
+              NT4Topic(
+                name: '/Non-Registered/Value 2',
+                type: NT4TypeStr.kInt,
+                properties: {},
+              ),
+              NT4Topic(
+                name: '/Non-Registered/Value 3',
+                type: NT4TypeStr.kInt,
+                properties: {},
+              ),
+            ],
+            virtualValues: {
+              '/Non-Registered/.type': 'Non Registered Type',
+            },
+          ),
+          preferences: preferences,
+          version: '0.0.0.0',
+          updateChecker: createMockUpdateChecker(),
+        ),
+      ),
+    );
+
+    await widgetTester.pumpAndSettle();
+
+    final addWidget = find.widgetWithText(MenuItemButton, 'Add Widget');
+
+    expect(addWidget, findsOneWidget);
+    expect(find.widgetWithText(DraggableDialog, 'Add Widget'), findsNothing);
+
+    MenuItemButton addWidgetButton =
+        addWidget.evaluate().first.widget as MenuItemButton;
+
+    addWidgetButton.onPressed?.call();
+
+    await widgetTester.pumpAndSettle();
+
+    expect(find.widgetWithText(DraggableDialog, 'Add Widget'), findsOneWidget);
+
+    final nonRegisteredTile = find.widgetWithText(TreeTile, 'Non-Registered');
+
+    expect(nonRegisteredTile, findsOneWidget);
+
+    final nonRegistered =
+        find.widgetWithText(WidgetContainer, 'Non-Registered');
+    expect(nonRegistered, findsNothing);
+
+    await widgetTester.drag(
+      nonRegisteredTile,
+      const Offset(250, 0),
+      kind: PointerDeviceKind.mouse,
+    );
+    await widgetTester.pumpAndSettle();
+
+    expect(nonRegistered, findsOneWidget);
   });
 
   testWidgets('List Layouts', (widgetTester) async {


### PR DESCRIPTION
- Allows sendables with an unknown/unregistered type to be turned into a list layout
- Speeds up creation of list layouts
- Fixes an issue with list layouts not unsubscribing if a drag finishes before list layout is created

Resolves #141 