### PR TITLE
Camera stream optimizations

### DIFF
--- a/lib/services/log.dart
+++ b/lib/services/log.dart
@@ -62,6 +62,10 @@ class Log {
   void debug(dynamic message, [dynamic error, StackTrace? stackTrace]) {
     log(Level.debug, message, error, stackTrace);
   }
+
+  void trace(dynamic message, [dynamic error, StackTrace? stackTrace]) {
+    log(Level.trace, message, error, stackTrace);
+  }
 }
 
 Log get logger => Log.instance;

--- a/lib/widgets/mjpeg.dart
+++ b/lib/widgets/mjpeg.dart
@@ -4,32 +4,8 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
-import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:http/http.dart';
 import 'package:visibility_detector/visibility_detector.dart';
-
-class _MjpegStateNotifier extends ChangeNotifier {
-  bool _mounted = true;
-  bool _visible = true;
-
-  _MjpegStateNotifier() : super();
-
-  bool get mounted => _mounted;
-
-  bool get visible => _visible;
-
-  set visible(value) {
-    _visible = value;
-    notifyListeners();
-  }
-
-  @override
-  void dispose() {
-    _mounted = false;
-    notifyListeners();
-    super.dispose();
-  }
-}
 
 /// A preprocessor for each JPEG frame from an MJPEG stream.
 class MjpegPreprocessor {
@@ -37,9 +13,8 @@ class MjpegPreprocessor {
 }
 
 /// An Mjpeg.
-class Mjpeg extends HookWidget {
-  final streamKey = UniqueKey();
-  final MjpegStreamState mjpegStream;
+class Mjpeg extends StatefulWidget {
+  final MjpegController controller;
   final BoxFit? fit;
   final double? width;
   final double? height;
@@ -47,8 +22,8 @@ class Mjpeg extends HookWidget {
   final Widget Function(BuildContext contet, dynamic error, dynamic stack)?
       error;
 
-  Mjpeg({
-    required this.mjpegStream,
+  const Mjpeg({
+    required this.controller,
     this.width,
     this.height,
     this.fit,
@@ -58,86 +33,96 @@ class Mjpeg extends HookWidget {
   });
 
   @override
+  State<Mjpeg> createState() => _MjpegState();
+}
+
+class _MjpegState extends State<Mjpeg> {
+  final streamKey = UniqueKey();
+
+  late void Function() listener;
+
+  @override
+  void initState() {
+    listener = () => setState(() {});
+    widget.controller.addListener(listener);
+    widget.controller.errorState.addListener(listener);
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    widget.controller.removeListener(listener);
+    widget.controller.errorState.removeListener(listener);
+
+    widget.controller.setMounted(streamKey, false);
+    widget.controller.setVisible(streamKey, false);
+
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    final image = useState<MemoryImage?>(null);
-    final state = useMemoized(() => _MjpegStateNotifier());
-    final visible = useListenable(state);
-    final errorState = useState<List<dynamic>?>(null);
-    isMounted() => context.mounted;
+    final controller = widget.controller;
 
-    final manager = useMemoized(
-        () => _StreamManager(
-              mjpegStream: mjpegStream,
-              mounted: isMounted,
-              visible: () => visible.visible,
-            ),
-        [
-          visible.visible,
-          isMounted(),
-          mjpegStream,
-        ]);
+    controller.setMounted(streamKey, context.mounted);
 
-    final key = useMemoized(() => UniqueKey(), [manager]);
+    if (controller.isVisible(streamKey)) {
+      controller.startStream();
+    }
 
-    useEffect(() {
-      errorState.value = null;
-      manager.updateStream(streamKey, image, errorState);
-      return () {
-        if (visible.visible && isMounted()) {
-          return;
-        }
-        mjpegStream.cancelSubscription(streamKey);
-      };
-    }, [manager]);
-
-    if (errorState.value != null && kDebugMode) {
+    if (controller.errorState.value != null && kDebugMode) {
       return SizedBox(
-        width: width,
-        height: height,
-        child: error == null
+        width: widget.width,
+        height: widget.height,
+        child: widget.error == null
             ? Center(
                 child: Padding(
                   padding: const EdgeInsets.all(8.0),
                   child: Text(
-                    '${errorState.value}',
+                    '${controller.errorState.value}',
                     textAlign: TextAlign.center,
                     style: const TextStyle(color: Colors.red),
                   ),
                 ),
               )
-            : error!(context, errorState.value!.first, errorState.value!.last),
+            : widget.error!(context, controller.errorState.value!.first,
+                controller.errorState.value!.last),
       );
     }
 
-    if ((image.value == null && mjpegStream.previousImage == null) ||
-        errorState.value != null) {
-      return SizedBox(
-          width: width,
-          height: height,
-          child: loading == null
-              ? const Center(child: CircularProgressIndicator())
-              : loading!(context));
-    }
-
     return VisibilityDetector(
-      key: key,
-      child: Image(
-        image: image.value ?? mjpegStream.previousImage!,
-        width: width,
-        height: height,
-        gaplessPlayback: true,
-        fit: fit,
-      ),
+      key: streamKey,
+      child: StreamBuilder<List<int>?>(
+          stream: controller.imageStream.stream,
+          builder: (context, snapshot) {
+            if ((snapshot.data == null && controller.previousImage == null) ||
+                controller.errorState.value != null) {
+              return SizedBox(
+                width: widget.width,
+                height: widget.height,
+                child: widget.loading?.call(context) ??
+                    const Center(child: CircularProgressIndicator()),
+              );
+            }
+
+            return Image.memory(
+              Uint8List.fromList(snapshot.data ?? controller.previousImage!),
+              width: widget.width,
+              height: widget.height,
+              gaplessPlayback: true,
+              fit: widget.fit,
+            );
+          }),
       onVisibilityChanged: (VisibilityInfo info) {
-        if (visible.mounted) {
-          visible.visible = info.visibleFraction != 0;
+        if (controller.isMounted(streamKey)) {
+          controller.setVisible(streamKey, info.visibleFraction != 0);
         }
       },
     );
   }
 }
 
-class MjpegStreamState {
+class MjpegController extends ChangeNotifier {
   static const _trigger = 0xFF;
   static const _soi = 0xD8;
   static const _eoi = 0xD9;
@@ -147,169 +132,95 @@ class MjpegStreamState {
   final Duration timeout;
   final Map<String, String> headers;
   Client httpClient = Client();
-  Stream<List<int>>? byteStream;
+
+  StreamSubscription<List<int>>? _rawSubscription;
+
+  ValueNotifier<List<dynamic>?> errorState = ValueNotifier(null);
+  StreamController<List<int>?> imageStream = StreamController.broadcast();
+  List<int>? previousImage;
 
   final MjpegPreprocessor? preprocessor;
 
-  MemoryImage? previousImage;
+  final Set<Key> _mountedKeys = {};
+  final Set<Key> _visibleKeys = {};
 
-  final Map<Key, StreamSubscription> _subscriptions = {};
+  bool isVisible(Key key) => _visibleKeys.contains(key);
 
-  StreamSubscription? _bitSubscription;
-  int bitCount = 0;
-  double bandwidth = 0.0;
+  void setVisible(Key key, bool value) {
+    if (value) {
+      bool hasChanged = !_visibleKeys.contains(key);
+      _visibleKeys.add(key);
 
-  late final Timer bandwidthTimer;
+      if (hasChanged) {
+        notifyListeners();
+      }
+    } else {
+      _visibleKeys.remove(key);
 
-  MjpegStreamState({
+      if (_visibleKeys.isEmpty) {
+        stopStream();
+      }
+    }
+  }
+
+  bool isMounted(Key key) => _mountedKeys.contains(key);
+
+  void setMounted(Key key, bool value) {
+    if (value) {
+      _mountedKeys.add(key);
+    } else {
+      _mountedKeys.remove(key);
+    }
+  }
+
+  bool get isStreaming => _rawSubscription != null;
+
+  MjpegController({
     required this.stream,
     this.isLive = true,
     this.timeout = const Duration(seconds: 5),
     this.headers = const {},
     this.preprocessor,
-  }) {
-    bandwidthTimer = Timer.periodic(const Duration(seconds: 1), (timer) {
-      bandwidth = bitCount / 1e6;
+  });
 
-      bitCount = 0;
-    });
+  @override
+  void dispose() {
+    stopStream();
+    imageStream.close();
+    super.dispose();
   }
 
-  void dispose({bool deleting = false}) {
-    for (StreamSubscription subscription in _subscriptions.values) {
-      subscription.cancel();
+  void startStream() async {
+    if (isStreaming) {
+      return;
     }
-    _subscriptions.clear();
-    _bitSubscription?.cancel();
-    _bitSubscription = null;
-    byteStream = null;
-    httpClient.close();
-    httpClient = Client();
-    bitCount = 0;
+    Stream<List<int>>? byteStream;
+    try {
+      final request = Request('GET', Uri.parse(stream));
+      request.headers.addAll(headers);
+      final response = await httpClient.send(request).timeout(
+          timeout); //timeout is to prevent process to hang forever in some case
 
-    if (deleting) {
-      bandwidthTimer.cancel();
-    }
-  }
-
-  void cancelSubscription(Key key) {
-    if (_subscriptions.containsKey(key)) {
-      _subscriptions.remove(key)!.cancel();
-
-      if (_subscriptions.isEmpty) {
-        dispose();
+      if (response.statusCode >= 200 && response.statusCode < 300) {
+        byteStream = response.stream;
+      } else {
+        if (_mountedKeys.isNotEmpty) {
+          errorState.value = [
+            HttpException('Stream returned ${response.statusCode} status'),
+            StackTrace.current
+          ];
+          imageStream.add(null);
+        }
+        stopStream();
       }
-    }
-  }
-
-  void sendImage(
-    ValueNotifier<MemoryImage?> image,
-    ValueNotifier<dynamic> errorState,
-    List<int> chunks, {
-    required bool Function() mounted,
-  }) async {
-    // pass image through preprocessor sending to [Image] for rendering
-    final List<int>? imageData;
-
-    if (preprocessor != null) {
-      imageData = preprocessor?.process(chunks);
-    } else {
-      imageData = chunks;
-    }
-
-    if (imageData == null) return;
-
-    final imageMemory = MemoryImage(Uint8List.fromList(imageData));
-    previousImage?.evict();
-    previousImage = imageMemory;
-    if (mounted()) {
-      errorState.value = null;
-      image.value = imageMemory;
-    }
-  }
-
-  void _onDataReceived({
-    required List<int> carry,
-    required List<int> chunk,
-    required ValueNotifier<MemoryImage?> image,
-    required ValueNotifier<List<dynamic>?> errorState,
-    required bool Function() mounted,
-  }) async {
-    if (carry.isNotEmpty && carry.last == _trigger) {
-      if (chunk.first == _eoi) {
-        carry.add(chunk.first);
-        sendImage(image, errorState, carry, mounted: mounted);
-        carry = [];
-        if (!isLive) {
-          dispose();
-        }
-      }
-    }
-
-    for (var i = 0; i < chunk.length - 1; i++) {
-      final d = chunk[i];
-      final d1 = chunk[i + 1];
-
-      if (d == _trigger && d1 == _soi) {
-        carry = [];
-        carry.add(d);
-      } else if (d == _trigger && d1 == _eoi && carry.isNotEmpty) {
-        carry.add(d);
-        carry.add(d1);
-
-        sendImage(image, errorState, carry, mounted: mounted);
-        carry = [];
-        if (!isLive) {
-          dispose();
-        }
-      } else if (carry.isNotEmpty) {
-        carry.add(d);
-        if (i == chunk.length - 2) {
-          carry.add(d1);
-        }
-      }
-    }
-  }
-
-  void updateStream(
-    Key key,
-    ValueNotifier<MemoryImage?> image,
-    ValueNotifier<List<dynamic>?> errorState, {
-    required bool Function() visible,
-    required bool Function() mounted,
-  }) async {
-    if (byteStream == null && visible() && mounted()) {
-      try {
-        final request = Request('GET', Uri.parse(stream));
-        request.headers.addAll(headers);
-        final response = await httpClient.send(request).timeout(
-            timeout); //timeout is to prevent process to hang forever in some case
-
-        if (response.statusCode >= 200 && response.statusCode < 300) {
-          byteStream = response.stream.asBroadcastStream();
-
-          _bitSubscription = byteStream!.listen((data) {
-            bitCount += data.length * Uint8List.bytesPerElement * 8;
-          });
-        } else {
-          if (mounted()) {
-            errorState.value = [
-              HttpException('Stream returned ${response.statusCode} status'),
-              StackTrace.current
-            ];
-            image.value = null;
-          }
-          dispose();
-        }
-      } catch (error, stack) {
-        // we ignore those errors in case play/pause is triggers
-        if (!error
-            .toString()
-            .contains('Connection closed before full header was received')) {
-          if (mounted()) {
-            errorState.value = [error, stack];
-            image.value = null;
-          }
+    } catch (error, stack) {
+      // we ignore those errors in case play/pause is triggers
+      if (!error
+          .toString()
+          .contains('Connection closed before full header was received')) {
+        if (_mountedKeys.isNotEmpty) {
+          errorState.value = [error, stack];
+          imageStream.add(null);
         }
       }
     }
@@ -318,49 +229,58 @@ class MjpegStreamState {
       return;
     }
 
-    var carry = <int>[];
-    _subscriptions.putIfAbsent(
-        key,
-        () => byteStream!.listen((chunk) {
-              if (!visible() || !mounted()) {
-                carry.clear();
-                return;
-              }
-              _onDataReceived(
-                carry: carry,
-                chunk: chunk,
-                image: image,
-                errorState: errorState,
-                mounted: mounted,
-              );
-            }, onError: (error, stack) {
-              try {
-                if (mounted()) {
-                  errorState.value = [error, stack];
-                  image.value = null;
-                }
-              } finally {
-                dispose();
-              }
-            }, cancelOnError: true));
+    var buffer = <int>[];
+    _rawSubscription = byteStream.listen((data) {
+      _handleData(buffer, data);
+    });
   }
-}
 
-class _StreamManager {
-  final MjpegStreamState mjpegStream;
+  void stopStream() async {
+    await _rawSubscription?.cancel();
+    _rawSubscription = null;
+    httpClient.close();
+    httpClient = Client();
+  }
 
-  final bool Function() mounted;
-  final bool Function() visible;
+  void _handleNewPacket(List<int> packet) {
+    previousImage = packet;
+    List<int> imageData = preprocessor?.process(packet) ?? packet;
+    imageStream.add(imageData);
+  }
 
-  _StreamManager({
-    required this.mjpegStream,
-    required this.mounted,
-    required this.visible,
-  });
+  void _handleData(List<int> buffer, List<int> data) {
+    if (buffer.isNotEmpty && buffer.last == _trigger) {
+      if (data.first == _eoi) {
+        buffer.add(data.first);
+        _handleNewPacket(buffer);
+        buffer = [];
+        if (!isLive) {
+          dispose();
+        }
+      }
+    }
+    for (var i = 0; i < data.length - 1; i++) {
+      final d = data[i];
+      final d1 = data[i + 1];
 
-  void updateStream(Key key, ValueNotifier<MemoryImage?> image,
-      ValueNotifier<List<dynamic>?> errorState) async {
-    mjpegStream.updateStream(key, image, errorState,
-        visible: visible, mounted: mounted);
+      if (d == _trigger && d1 == _soi) {
+        buffer = [];
+        buffer.add(d);
+      } else if (d == _trigger && d1 == _eoi && buffer.isNotEmpty) {
+        buffer.add(d);
+        buffer.add(d1);
+
+        _handleNewPacket(buffer);
+        buffer = [];
+        if (!isLive) {
+          dispose();
+        }
+      } else if (buffer.isNotEmpty) {
+        buffer.add(d);
+        if (i == buffer.length - 2) {
+          buffer.add(d1);
+        }
+      }
+    }
   }
 }

--- a/lib/widgets/mjpeg.dart
+++ b/lib/widgets/mjpeg.dart
@@ -119,36 +119,12 @@ class _MjpegState extends State<Mjpeg> {
               );
             }
 
-            return Column(
-              mainAxisAlignment: MainAxisAlignment.center,
-              children: [
-                Row(
-                  children: [
-                    ValueListenableBuilder(
-                      valueListenable: controller.framesPerSecond,
-                      builder: (context, value, child) => Text('FPS: $value'),
-                    ),
-                    const Spacer(),
-                    ValueListenableBuilder(
-                      valueListenable: controller.bandwidth,
-                      builder: (context, value, child) =>
-                          Text('Bandwidth: ${value.toStringAsFixed(2)} Mbps'),
-                    ),
-                  ],
-                ),
-                Flexible(
-                  child: Image.memory(
-                    Uint8List.fromList(
-                        snapshot.data ?? controller.previousImage!),
-                    width: widget.width,
-                    height: widget.height,
-                    gaplessPlayback: true,
-                    fit: widget.fit,
-                  ),
-                ),
-                // To keep the image centered in the widget
-                const Text(''),
-              ],
+            return Image.memory(
+              Uint8List.fromList(snapshot.data ?? controller.previousImage!),
+              width: widget.width,
+              height: widget.height,
+              gaplessPlayback: true,
+              fit: widget.fit,
             );
           }),
       onVisibilityChanged: (VisibilityInfo info) {

--- a/lib/widgets/mjpeg.dart
+++ b/lib/widgets/mjpeg.dart
@@ -1,12 +1,13 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:elastic_dashboard/services/log.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 
 import 'package:http/http.dart';
 import 'package:visibility_detector/visibility_detector.dart';
+
+import 'package:elastic_dashboard/services/log.dart';
 
 /// A preprocessor for each JPEG frame from an MJPEG stream.
 class MjpegPreprocessor {
@@ -127,7 +128,7 @@ class _MjpegState extends State<Mjpeg> {
               height: widget.height,
               gaplessPlayback: true,
               fit: widget.fit,
-              scale: (widget.expandToFit) ? 1e-100 : 1.0,
+              scale: (widget.expandToFit) ? 1e-6 : 1.0,
             );
           }),
       onVisibilityChanged: (VisibilityInfo info) {
@@ -226,6 +227,7 @@ class MjpegController extends ChangeNotifier {
     if (isStreaming) {
       return;
     }
+    logger.debug('Starting camera stream on URL $stream');
     Stream<List<int>>? byteStream;
     try {
       final request = Request('GET', Uri.parse(stream));
@@ -279,10 +281,12 @@ class MjpegController extends ChangeNotifier {
   }
 
   void stopStream() async {
-    logger.debug('Stopping camera stream for $stream');
+    logger.debug('Stopping camera stream on URL $stream');
     await _rawSubscription?.cancel();
     _metricsTimer?.cancel();
     _rawSubscription = null;
+    _bitCount = 0;
+    _frameCount = 0;
     httpClient.close();
     httpClient = Client();
   }

--- a/lib/widgets/mjpeg.dart
+++ b/lib/widgets/mjpeg.dart
@@ -17,6 +17,7 @@ class MjpegPreprocessor {
 class Mjpeg extends StatefulWidget {
   final MjpegController controller;
   final BoxFit? fit;
+  final bool expandToFit;
   final double? width;
   final double? height;
   final WidgetBuilder? loading;
@@ -28,6 +29,7 @@ class Mjpeg extends StatefulWidget {
     this.width,
     this.height,
     this.fit,
+    this.expandToFit = false,
     this.error,
     this.loading,
     super.key,
@@ -125,6 +127,7 @@ class _MjpegState extends State<Mjpeg> {
               height: widget.height,
               gaplessPlayback: true,
               fit: widget.fit,
+              scale: (widget.expandToFit) ? 1e-100 : 1.0,
             );
           }),
       onVisibilityChanged: (VisibilityInfo info) {

--- a/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
+++ b/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
@@ -85,7 +85,12 @@ class CameraStreamModel extends MultiTopicNTWidgetModel {
         .toList();
 
     if (resolution != null && resolution.length > 1) {
-      _resolution = Size(resolution[0].toDouble(), resolution[1].toDouble());
+      if (resolution[0] % 2 != 0) {
+        resolution[0] += 1;
+      }
+      if (resolution[0] > 0 && resolution[1] > 0) {
+        _resolution = Size(resolution[0].toDouble(), resolution[1].toDouble());
+      }
     }
   }
 
@@ -158,7 +163,12 @@ class CameraStreamModel extends MultiTopicNTWidgetModel {
                       return;
                     }
 
-                    resolution = Size(newWidth.toDouble(),
+                    if (newWidth! % 2 != 0) {
+                      // Won't allow += for some reason
+                      newWidth = newWidth! + 1;
+                    }
+
+                    resolution = Size(newWidth!.toDouble(),
                         resolution?.height.toDouble() ?? 0);
                   });
                 },

--- a/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
+++ b/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
@@ -310,14 +310,38 @@ class CameraStreamWidget extends NTWidget {
           model.controller = MjpegController(stream: stream);
         }
 
-        return Stack(
-          fit: StackFit.expand,
-          children: [
-            Mjpeg(
-              controller: model.controller!,
-              fit: BoxFit.contain,
-            ),
-          ],
+        return IntrinsicWidth(
+          child: Stack(
+            fit: StackFit.expand,
+            children: [
+              Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  Row(
+                    children: [
+                      ValueListenableBuilder(
+                        valueListenable: model.controller!.framesPerSecond,
+                        builder: (context, value, child) => Text('FPS: $value'),
+                      ),
+                      const Spacer(),
+                      ValueListenableBuilder(
+                        valueListenable: model.controller!.bandwidth,
+                        builder: (context, value, child) =>
+                            Text('Bandwidth: ${value.toStringAsFixed(2)} Mbps'),
+                      ),
+                    ],
+                  ),
+                  Flexible(
+                    child: Mjpeg(
+                      controller: model.controller!,
+                      fit: BoxFit.contain,
+                    ),
+                  ),
+                  const Text(''),
+                ],
+              ),
+            ],
+          ),
         );
       },
     );

--- a/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
+++ b/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
@@ -315,7 +315,6 @@ class CameraStreamWidget extends NTWidget {
           children: [
             Mjpeg(
               controller: model.controller!,
-              // mjpegStream: model.mjpegStream!,
               fit: BoxFit.contain,
             ),
           ],

--- a/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
+++ b/lib/widgets/nt_widgets/multi-topic/camera_stream.dart
@@ -311,35 +311,31 @@ class CameraStreamWidget extends NTWidget {
         }
 
         return IntrinsicWidth(
-          child: Stack(
-            fit: StackFit.expand,
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Column(
-                mainAxisAlignment: MainAxisAlignment.center,
+              Row(
                 children: [
-                  Row(
-                    children: [
-                      ValueListenableBuilder(
-                        valueListenable: model.controller!.framesPerSecond,
-                        builder: (context, value, child) => Text('FPS: $value'),
-                      ),
-                      const Spacer(),
-                      ValueListenableBuilder(
-                        valueListenable: model.controller!.bandwidth,
-                        builder: (context, value, child) =>
-                            Text('Bandwidth: ${value.toStringAsFixed(2)} Mbps'),
-                      ),
-                    ],
+                  ValueListenableBuilder(
+                    valueListenable: model.controller!.framesPerSecond,
+                    builder: (context, value, child) => Text('FPS: $value'),
                   ),
-                  Flexible(
-                    child: Mjpeg(
-                      controller: model.controller!,
-                      fit: BoxFit.contain,
-                    ),
+                  const Spacer(),
+                  ValueListenableBuilder(
+                    valueListenable: model.controller!.bandwidth,
+                    builder: (context, value, child) =>
+                        Text('Bandwidth: ${value.toStringAsFixed(2)} Mbps'),
                   ),
-                  const Text(''),
                 ],
               ),
+              Flexible(
+                child: Mjpeg(
+                  controller: model.controller!,
+                  fit: BoxFit.contain,
+                  expandToFit: true,
+                ),
+              ),
+              const Text(''),
             ],
           ),
         );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -406,14 +406,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
-  flutter_hooks:
-    dependency: "direct main"
-    description:
-      name: flutter_hooks
-      sha256: cde36b12f7188c85286fba9b38cc5a902e7279f36dd676967106c041dc9dde70
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.20.5"
   flutter_launcher_icons:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,6 @@ dependencies:
   flutter_colorpicker: ^1.1.0
   flutter_context_menu: ^0.1.3
   flutter_fancy_tree_view: ^1.1.1
-  flutter_hooks: ^0.20.0
   flutter_launcher_icons: ^0.13.1
   github: ^9.17.0
   http: ^1.2.0

--- a/test/widgets/nt_widgets/multi-topic/camera_stream_test.dart
+++ b/test/widgets/nt_widgets/multi-topic/camera_stream_test.dart
@@ -69,6 +69,47 @@ void main() {
     expect(cameraStreamModel.getUrlWithParameters('0.0.0.0'), '0.0.0.0?');
   });
 
+  test('Camera stream from json (with invalid resolution)', () {
+    NTWidgetModel cameraStreamModel = NTWidgetBuilder.buildNTModelFromJson(
+      ntConnection,
+      preferences,
+      'Camera Stream',
+      {...cameraStreamJson}..update('resolution', (_) => [101.0, 100.0]),
+    );
+
+    expect(cameraStreamModel.type, 'Camera Stream');
+    expect(cameraStreamModel.runtimeType, CameraStreamModel);
+
+    if (cameraStreamModel is! CameraStreamModel) {
+      return;
+    }
+    expect(cameraStreamModel.resolution, const Size(102.0, 100.0));
+
+    expect(cameraStreamModel.getUrlWithParameters('0.0.0.0'),
+        '0.0.0.0?resolution=102x100&fps=60&compression=50');
+  });
+
+  test('Camera stream from json (with negative resolution)', () {
+    NTWidgetModel cameraStreamModel = NTWidgetBuilder.buildNTModelFromJson(
+      ntConnection,
+      preferences,
+      'Camera Stream',
+      {...cameraStreamJson}..update('resolution', (_) => [-1, 100.0]),
+    );
+
+    expect(cameraStreamModel.type, 'Camera Stream');
+    expect(cameraStreamModel.runtimeType, CameraStreamModel);
+
+    if (cameraStreamModel is! CameraStreamModel) {
+      return;
+    }
+
+    expect(cameraStreamModel.resolution, isNull);
+
+    expect(cameraStreamModel.getUrlWithParameters('0.0.0.0'),
+        '0.0.0.0?fps=60&compression=50');
+  });
+
   test('Camera stream to json', () {
     CameraStreamModel cameraStreamModel = CameraStreamModel(
       ntConnection: ntConnection,


### PR DESCRIPTION
Simplified the logic for the mjpeg stream decoding and display, along with adding text for bandwidth and FPS
* Use stream builder instead of flutter hooks
* Remove StreamManager, instead have one change notifier to hold the state and decoding streams
* Only start a camera stream when the widget becomes focused
* Rebuild the widget when focus changes, automatically restarting streams properly