### PR TITLE
Options for Remote Download Method

### DIFF
--- a/lib/widgets/dialog_widgets/dialog_dropdown_chooser.dart
+++ b/lib/widgets/dialog_widgets/dialog_dropdown_chooser.dart
@@ -3,13 +3,16 @@ import 'package:flutter/material.dart';
 class DialogDropdownChooser<T> extends StatefulWidget {
   final List<T>? choices;
   final T? initialValue;
-  final Function(T?) onSelectionChanged;
+  final void Function(T?) onSelectionChanged;
+  final String Function(T value)? nameMap;
 
-  const DialogDropdownChooser(
-      {super.key,
-      this.choices,
-      this.initialValue,
-      required this.onSelectionChanged});
+  const DialogDropdownChooser({
+    super.key,
+    this.choices,
+    this.initialValue,
+    required this.onSelectionChanged,
+    this.nameMap,
+  });
 
   @override
   State<DialogDropdownChooser<T>> createState() =>
@@ -47,7 +50,7 @@ class _DialogDropdownChooserState<T> extends State<DialogDropdownChooser<T>> {
               items: widget.choices?.map((T item) {
                 return DropdownMenuItem<T>(
                   value: item,
-                  child: Text(item.toString()),
+                  child: Text(widget.nameMap?.call(item) ?? item.toString()),
                 );
               }).toList(),
               value: selectedValue,

--- a/lib/widgets/tab_grid.dart
+++ b/lib/widgets/tab_grid.dart
@@ -45,7 +45,17 @@ class TabGridModel extends ChangeNotifier {
     required this.preferences,
     required Map<String, dynamic> jsonData,
     required this.onAddWidgetPressed,
-    Function(String message)? onJsonLoadingWarning,
+    void Function(String message)? onJsonLoadingWarning,
+  }) {
+    loadFromJson(
+      jsonData: jsonData,
+      onJsonLoadingWarning: onJsonLoadingWarning,
+    );
+  }
+
+  void loadFromJson({
+    required Map<String, dynamic> jsonData,
+    void Function(String message)? onJsonLoadingWarning,
   }) {
     if (jsonData['containers'] != null) {
       loadContainersFromJson(
@@ -57,15 +67,11 @@ class TabGridModel extends ChangeNotifier {
     if (jsonData['layouts'] != null) {
       loadLayoutsFromJson(jsonData, onJsonLoadingWarning: onJsonLoadingWarning);
     }
-
-    for (WidgetContainerModel model in _widgetModels) {
-      model.addListener(notifyListeners);
-    }
   }
 
   void mergeFromJson({
     required Map<String, dynamic> jsonData,
-    Function(String message)? onJsonLoadingWarning,
+    void Function(String message)? onJsonLoadingWarning,
   }) {
     if (jsonData['containers'] != null) {
       for (Map<String, dynamic> widgetData in jsonData['containers']) {
@@ -172,7 +178,7 @@ class TabGridModel extends ChangeNotifier {
   void loadContainersFromJson(Map<String, dynamic> jsonData,
       {Function(String message)? onJsonLoadingWarning}) {
     for (Map<String, dynamic> containerData in jsonData['containers']) {
-      _widgetModels.add(
+      addWidget(
         NTWidgetContainerModel.fromJson(
           ntConnection: ntConnection,
           preferences: preferences,
@@ -222,7 +228,7 @@ class TabGridModel extends ChangeNotifier {
           continue;
       }
 
-      _widgetModels.add(widget);
+      addWidget(widget);
     }
   }
 


### PR DESCRIPTION
Adds options for how to download the remote layout:
* Overwrite: Will keep existing tabs, but if the remote layout has a tab with the same name, the current one will be overwritten
* Merge: Keeps existing layout, and places new widgets where possible, will not delete anything
* Reload: Deletes the current layout and reloads from the remote one, the same as opening a new layout