### PR TITLE
Fix initial enabled state for list layouts

### DIFF
--- a/lib/widgets/tab_grid.dart
+++ b/lib/widgets/tab_grid.dart
@@ -64,7 +64,10 @@ class TabGridModel extends ChangeNotifier {
     }
 
     if (jsonData['layouts'] != null) {
-      loadLayoutsFromJson(jsonData, onJsonLoadingWarning: onJsonLoadingWarning);
+      loadLayoutsFromJson(
+        jsonData,
+        onJsonLoadingWarning: onJsonLoadingWarning,
+      );
     }
   }
 
@@ -157,6 +160,7 @@ class TabGridModel extends ChangeNotifier {
                 ntConnection: ntConnection,
                 jsonData: jsonData,
                 preferences: preferences,
+                enabled: ntConnection.isNT4Connected,
                 onJsonLoadingWarning: onJsonLoadingWarning,
               ),
               enabled: ntConnection.isNT4Connected,
@@ -211,6 +215,7 @@ class TabGridModel extends ChangeNotifier {
               ntConnection: ntConnection,
               jsonData: jsonData,
               preferences: preferences,
+              enabled: ntConnection.isNT4Connected,
               onJsonLoadingWarning: onJsonLoadingWarning,
             ),
             enabled: ntConnection.isNT4Connected,


### PR DESCRIPTION
When loading a list layout from a json, the enabled state of the widgets wasn't initialized, which was an issue when downloading layouts