### PR TITLE
Fix reconnection error messages

### DIFF
--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -2234,8 +2234,15 @@ class _DashboardPageState extends State<DashboardPage> with WindowListener {
                           .tabGrid
                           .placeDragInWidget(widget);
                     },
-                    onRemoveWidget: () =>
-                        _tabData[_currentTabIndex].tabGrid.removeDragInWidget(),
+                    onRemoveWidget: () {
+                      // Just in case if the tab index is somehow changed between frames
+                      int indexOnRemoval = _currentTabIndex;
+
+                      WidgetsBinding.instance.addPostFrameCallback((_) =>
+                          _tabData[indexOnRemoval]
+                              .tabGrid
+                              .removeDragInWidget());
+                    },
                     onClose: () {
                       setState(() => _addWidgetDialogVisible = false);
                     },

--- a/lib/widgets/nt_widgets/multi-topic/combo_box_chooser.dart
+++ b/lib/widgets/nt_widgets/multi-topic/combo_box_chooser.dart
@@ -121,7 +121,7 @@ class ComboBoxChooserModel extends MultiTopicNTWidgetModel {
     _selectedTopic ??=
         ntConnection.publishNewTopic(selectedTopicName, NT4TypeStr.kString);
 
-    ntConnection.updateDataFromTopic(_selectedTopic!, selected);
+    Future(() => ntConnection.updateDataFromTopic(_selectedTopic!, selected));
   }
 }
 

--- a/lib/widgets/nt_widgets/multi-topic/split_button_chooser.dart
+++ b/lib/widgets/nt_widgets/multi-topic/split_button_chooser.dart
@@ -75,7 +75,7 @@ class SplitButtonChooserModel extends MultiTopicNTWidgetModel {
     _selectedTopic ??=
         ntConnection.publishNewTopic(selectedTopicName, NT4TypeStr.kString);
 
-    ntConnection.updateDataFromTopic(_selectedTopic!, selected);
+    Future(() => ntConnection.updateDataFromTopic(_selectedTopic!, selected));
   }
 }
 


### PR DESCRIPTION
When reconnecting the ComboBox Chooser, Split Button Chooser, and a widget dragging in (conditionally) would throw error messages