### PR TITLE
Prevent simultaneous connections

### DIFF
--- a/lib/services/nt4_client.dart
+++ b/lib/services/nt4_client.dart
@@ -567,6 +567,11 @@ class NT4Client {
       return;
     }
 
+    // while trying to establish the connection, block out any other connection attempts
+    // prevents duplicate clients from being created on networktables
+    bool wasAttempting = _attemptingConnection;
+    _attemptingConnection = false;
+
     _clientId = Random().nextInt(99999999);
 
     String mainServerAddr = 'ws://$serverBaseAddress:5810/nt/Elastic';
@@ -583,7 +588,8 @@ class NT4Client {
       // Failed to connect... try again
       logger.info(
           'Failed to connect to network tables, attempting to reconnect in 500 ms');
-      if (_attemptingConnection) {
+      if (wasAttempting) {
+        _attemptingConnection = true;
         Future.delayed(const Duration(milliseconds: 500), _connect);
       }
       return;


### PR DESCRIPTION
Previously, if the IP address was changed while network tables was disconnected, there would be a new connection attempt "loop" that tried to connect at the same time as the existing connection attempt "loop(s)". When the connection was eventually established, multiple clients would be created on Network Tables.

Now, when trying to connect, any additional calls to `_connect()` while trying to connect will be blocked off, preventing this issue