### PR TITLE
Add noscript text saying JS is required

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -18,6 +18,9 @@
   <link rel="manifest" href="manifest.json">
 </head>
 <body>
+  <noscript>
+    <p>You need to use a JavaScript-enabled browser to run Elastic.</p>
+  </noscript>
   <script>
     // This prevents default browser actions on key combinations.
     // See https://stackoverflow.com/a/67039463/6509751.


### PR DESCRIPTION
This may be useful in some cases where someone tries loading this in an environment where JavaScript is nonfunctional or if they forgot to enable it.

This is definitely a niche thing, feel free to reject it; this seemed easier than opening an issue.