### PR TITLE
Remove forceDispose()

### DIFF
--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -567,7 +567,7 @@ class _DashboardPageState extends State<DashboardPage>
   }
 
   @override
-  void dispose() async {
+  void dispose() {
     removeUnloadHandler();
     windowManager.removeListener(this);
     model._state = null;

--- a/lib/services/field_images.dart
+++ b/lib/services/field_images.dart
@@ -143,7 +143,7 @@ class Field {
         );
   }
 
-  void dispose() async {
+  Future<void> dispose() async {
     logger.debug('Soft disposing field: $game');
     instanceCount--;
     logger.trace('New instance count for $game: $instanceCount');

--- a/lib/widgets/dialog_widgets/layout_drag_tile.dart
+++ b/lib/widgets/dialog_widgets/layout_drag_tile.dart
@@ -40,9 +40,11 @@ class _LayoutDragTileState extends State<LayoutDragTile> {
     if (draggingWidget != null) {
       draggingWidget?.unSubscribe();
       draggingWidget?.disposeModel(deleting: true);
-      draggingWidget?.forceDispose();
+      draggingWidget?.dispose();
 
       widget.onRemoveWidget();
+
+      draggingWidget = null;
     }
   }
 

--- a/lib/widgets/dialog_widgets/layout_drag_tile.dart
+++ b/lib/widgets/dialog_widgets/layout_drag_tile.dart
@@ -39,7 +39,7 @@ class _LayoutDragTileState extends State<LayoutDragTile> {
   void cancelDrag() {
     if (draggingWidget != null) {
       draggingWidget?.unSubscribe();
-      draggingWidget?.disposeModel(deleting: true);
+      draggingWidget?.softDispose(deleting: true);
       draggingWidget?.dispose();
 
       widget.onRemoveWidget();

--- a/lib/widgets/draggable_containers/models/list_layout_model.dart
+++ b/lib/widgets/draggable_containers/models/list_layout_model.dart
@@ -244,7 +244,7 @@ class ListLayoutModel extends LayoutContainerModel {
                                           container.disposeModel(
                                             deleting: true,
                                           );
-                                          container.forceDispose();
+                                          container.dispose();
 
                                           notifyListeners();
                                         });

--- a/lib/widgets/draggable_containers/models/list_layout_model.dart
+++ b/lib/widgets/draggable_containers/models/list_layout_model.dart
@@ -149,11 +149,11 @@ class ListLayoutModel extends LayoutContainerModel {
   }
 
   @override
-  void disposeModel({bool deleting = false}) {
-    super.disposeModel(deleting: deleting);
+  void softDispose({bool deleting = false}) {
+    super.softDispose(deleting: deleting);
 
     for (var child in children) {
-      child.disposeModel(deleting: deleting);
+      child.softDispose(deleting: deleting);
     }
   }
 
@@ -241,9 +241,7 @@ class ListLayoutModel extends LayoutContainerModel {
                                           children.remove(container);
 
                                           container.unSubscribe();
-                                          container.disposeModel(
-                                            deleting: true,
-                                          );
+                                          container.softDispose(deleting: true);
                                           container.dispose();
 
                                           notifyListeners();

--- a/lib/widgets/draggable_containers/models/nt_widget_container_model.dart
+++ b/lib/widgets/draggable_containers/models/nt_widget_container_model.dart
@@ -109,9 +109,9 @@ class NTWidgetContainerModel extends WidgetContainerModel {
   }
 
   @override
-  void forceDispose() {
-    super.forceDispose();
-    childModel.forceDispose();
+  void dispose() {
+    childModel.dispose();
+    super.dispose();
   }
 
   @override
@@ -362,7 +362,7 @@ class NTWidgetContainerModel extends WidgetContainerModel {
 
     childModel.disposeWidget(deleting: true);
     childModel.unSubscribe();
-    childModel.forceDispose();
+    childModel.dispose();
 
     childModel = NTWidgetBuilder.buildNTModelFromType(
       ntConnection,

--- a/lib/widgets/draggable_containers/models/nt_widget_container_model.dart
+++ b/lib/widgets/draggable_containers/models/nt_widget_container_model.dart
@@ -102,10 +102,10 @@ class NTWidgetContainerModel extends WidgetContainerModel {
   }
 
   @override
-  void disposeModel({bool deleting = false}) {
-    super.disposeModel(deleting: deleting);
+  void softDispose({bool deleting = false}) {
+    super.softDispose(deleting: deleting);
 
-    childModel.disposeWidget(deleting: deleting);
+    childModel.softDispose(deleting: deleting);
   }
 
   @override
@@ -360,7 +360,7 @@ class NTWidgetContainerModel extends WidgetContainerModel {
       return;
     }
 
-    childModel.disposeWidget(deleting: true);
+    childModel.softDispose(deleting: true);
     childModel.unSubscribe();
     childModel.dispose();
 

--- a/lib/widgets/draggable_containers/models/widget_container_model.dart
+++ b/lib/widgets/draggable_containers/models/widget_container_model.dart
@@ -217,7 +217,7 @@ abstract class WidgetContainerModel extends ChangeNotifier {
     return [];
   }
 
-  void disposeModel({bool deleting = false}) {}
+  void softDispose({bool deleting = false}) {}
 
   void unSubscribe() {}
 

--- a/lib/widgets/draggable_containers/models/widget_container_model.dart
+++ b/lib/widgets/draggable_containers/models/widget_container_model.dart
@@ -31,9 +31,6 @@ abstract class WidgetContainerModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  bool _disposed = false;
-  bool _forceDispose = false;
-
   late Rect _draggingRect = Rect.fromLTWH(
     0,
     0,
@@ -176,26 +173,6 @@ abstract class WidgetContainerModel extends ChangeNotifier {
   }) : _enabled = enabled {
     fromJson(jsonData);
     init();
-  }
-
-  @override
-  void notifyListeners() {
-    if (!_disposed) {
-      super.notifyListeners();
-    }
-  }
-
-  @override
-  void dispose() {
-    if (!hasListeners || _forceDispose) {
-      super.dispose();
-      _disposed = true;
-    }
-  }
-
-  void forceDispose() {
-    _forceDispose = true;
-    dispose();
   }
 
   void init() {

--- a/lib/widgets/network_tree/networktables_tree.dart
+++ b/lib/widgets/network_tree/networktables_tree.dart
@@ -329,7 +329,7 @@ class _TreeTileState extends State<TreeTile> {
   void cancelDrag() {
     if (draggingWidget != null) {
       draggingWidget!.unSubscribe();
-      draggingWidget!.disposeModel(deleting: true);
+      draggingWidget!.softDispose(deleting: true);
       draggingWidget!.dispose();
 
       widget.onRemoveWidget?.call();
@@ -381,7 +381,7 @@ class _TreeTileState extends State<TreeTile> {
                 );
                 if (!dragging) {
                   draggingWidget?.unSubscribe();
-                  draggingWidget?.disposeModel(deleting: true);
+                  draggingWidget?.softDispose(deleting: true);
                   draggingWidget?.dispose();
 
                   draggingWidget = null;

--- a/lib/widgets/network_tree/networktables_tree.dart
+++ b/lib/widgets/network_tree/networktables_tree.dart
@@ -330,7 +330,7 @@ class _TreeTileState extends State<TreeTile> {
     if (draggingWidget != null) {
       draggingWidget!.unSubscribe();
       draggingWidget!.disposeModel(deleting: true);
-      draggingWidget!.forceDispose();
+      draggingWidget!.dispose();
 
       widget.onRemoveWidget?.call();
 
@@ -382,7 +382,7 @@ class _TreeTileState extends State<TreeTile> {
                 if (!dragging) {
                   draggingWidget?.unSubscribe();
                   draggingWidget?.disposeModel(deleting: true);
-                  draggingWidget?.forceDispose();
+                  draggingWidget?.dispose();
 
                   draggingWidget = null;
                 }

--- a/lib/widgets/network_tree/networktables_tree_row.dart
+++ b/lib/widgets/network_tree/networktables_tree_row.dart
@@ -232,7 +232,7 @@ class NetworkTableTreeRow {
 
     if (primary == null || !NTWidgetBuilder.isRegistered(primary.type)) {
       primary?.unSubscribe();
-      primary?.disposeWidget(deleting: true);
+      primary?.softDispose(deleting: true);
       primary?.dispose();
 
       if (resortToListLayout && listLayoutBuilder != null) {
@@ -253,7 +253,7 @@ class NetworkTableTreeRow {
 
     if (widget == null) {
       primary.unSubscribe();
-      primary.disposeWidget(deleting: true);
+      primary.softDispose(deleting: true);
       primary.dispose();
       return null;
     }
@@ -279,7 +279,7 @@ class NetworkTableTreeRow {
 
     if (widget == null) {
       primary.unSubscribe();
-      primary.disposeWidget(deleting: true);
+      primary.softDispose(deleting: true);
       primary.dispose();
 
       return null;

--- a/lib/widgets/network_tree/networktables_tree_row.dart
+++ b/lib/widgets/network_tree/networktables_tree_row.dart
@@ -233,7 +233,7 @@ class NetworkTableTreeRow {
     if (primary == null || !NTWidgetBuilder.isRegistered(primary.type)) {
       primary?.unSubscribe();
       primary?.disposeWidget(deleting: true);
-      primary?.forceDispose();
+      primary?.dispose();
 
       if (resortToListLayout && listLayoutBuilder != null) {
         List<NTWidgetContainerModel>? listLayoutChildren =
@@ -254,7 +254,7 @@ class NetworkTableTreeRow {
     if (widget == null) {
       primary.unSubscribe();
       primary.disposeWidget(deleting: true);
-      primary.forceDispose();
+      primary.dispose();
       return null;
     }
 
@@ -280,7 +280,7 @@ class NetworkTableTreeRow {
     if (widget == null) {
       primary.unSubscribe();
       primary.disposeWidget(deleting: true);
-      primary.forceDispose();
+      primary.dispose();
 
       return null;
     }

--- a/lib/widgets/nt_widgets/multi_topic/camera_stream.dart
+++ b/lib/widgets/nt_widgets/multi_topic/camera_stream.dart
@@ -293,13 +293,13 @@ class CameraStreamModel extends MultiTopicNTWidgetModel {
   }
 
   @override
-  void disposeWidget({bool deleting = false}) {
+  void softDispose({bool deleting = false}) {
     if (deleting) {
       controller?.dispose();
       ntConnection.ntConnected.removeListener(onNTConnected);
     }
 
-    super.disposeWidget(deleting: deleting);
+    super.softDispose(deleting: deleting);
   }
 
   void onNTConnected() {

--- a/lib/widgets/nt_widgets/multi_topic/field_widget.dart
+++ b/lib/widgets/nt_widgets/multi_topic/field_widget.dart
@@ -235,8 +235,8 @@ class FieldWidgetModel extends MultiTopicNTWidgetModel {
   }
 
   @override
-  void disposeWidget({bool deleting = false}) async {
-    super.disposeWidget(deleting: deleting);
+  void softDispose({bool deleting = false}) async {
+    super.softDispose(deleting: deleting);
 
     if (deleting) {
       await _field.dispose();

--- a/lib/widgets/nt_widgets/multi_topic/field_widget.dart
+++ b/lib/widgets/nt_widgets/multi_topic/field_widget.dart
@@ -235,11 +235,11 @@ class FieldWidgetModel extends MultiTopicNTWidgetModel {
   }
 
   @override
-  void disposeWidget({bool deleting = false}) {
+  void disposeWidget({bool deleting = false}) async {
     super.disposeWidget(deleting: deleting);
 
     if (deleting) {
-      _field.dispose();
+      await _field.dispose();
       ntConnection.removeTopicAnnounceListener(topicAnnounceListener);
     }
 
@@ -317,7 +317,7 @@ class FieldWidgetModel extends MultiTopicNTWidgetModel {
         ),
       ),
       DialogDropdownChooser<String?>(
-        onSelectionChanged: (value) {
+        onSelectionChanged: (value) async {
           if (value == null) {
             return;
           }
@@ -329,7 +329,7 @@ class FieldWidgetModel extends MultiTopicNTWidgetModel {
           }
 
           _fieldGame = value;
-          _field.dispose();
+          await _field.dispose();
           _field = newField;
 
           widgetSize = null;

--- a/lib/widgets/nt_widgets/multi_topic/pid_controller.dart
+++ b/lib/widgets/nt_widgets/multi_topic/pid_controller.dart
@@ -190,7 +190,7 @@ class PIDControllerWidget extends NTWidget {
 
         // Since they were null they're not being listened to when created during build
         if (wasNull) {
-          model.refresh();
+          Future(() => model.refresh());
         }
 
         // Updates the text of the text editing controller if the kp value has changed

--- a/lib/widgets/nt_widgets/multi_topic/profiled_pid_controller.dart
+++ b/lib/widgets/nt_widgets/multi_topic/profiled_pid_controller.dart
@@ -187,7 +187,7 @@ class ProfiledPIDControllerWidget extends NTWidget {
 
         // Since they were null they're not being listened to when created during build
         if (wasNull) {
-          model.refresh();
+          Future(() => model.refresh());
         }
 
         // Updates the text of the text editing controller if the kp value has changed

--- a/lib/widgets/nt_widgets/nt_widget.dart
+++ b/lib/widgets/nt_widgets/nt_widget.dart
@@ -77,7 +77,7 @@ sealed class NTWidgetModel extends ChangeNotifier {
 
   void unSubscribe();
 
-  void disposeWidget({bool deleting = false});
+  void softDispose({bool deleting = false});
 
   void resetSubscription();
 
@@ -236,7 +236,7 @@ class SingleTopicNTWidgetModel extends NTWidgetModel {
   }
 
   @override
-  void disposeWidget({bool deleting = false}) {}
+  void softDispose({bool deleting = false}) {}
 
   @override
   void resetSubscription() {
@@ -349,7 +349,7 @@ class MultiTopicNTWidgetModel extends NTWidgetModel {
   }
 
   @override
-  void disposeWidget({bool deleting = false}) {}
+  void softDispose({bool deleting = false}) {}
 }
 
 abstract class NTWidget extends StatelessWidget {

--- a/lib/widgets/nt_widgets/nt_widget.dart
+++ b/lib/widgets/nt_widgets/nt_widget.dart
@@ -43,9 +43,6 @@ sealed class NTWidgetModel extends ChangeNotifier {
 
   set period(double value) => _period = value;
 
-  bool _disposed = false;
-  bool _forceDispose = false;
-
   NTWidgetModel({
     required this.ntConnection,
     required this.preferences,
@@ -90,30 +87,7 @@ sealed class NTWidgetModel extends ChangeNotifier {
     return const [];
   }
 
-  void forceDispose() {
-    _forceDispose = true;
-    dispose();
-  }
-
-  @override
-  void dispose() {
-    if (!hasListeners || _forceDispose) {
-      super.dispose();
-
-      _disposed = true;
-    }
-  }
-
-  @override
-  void notifyListeners() {
-    if (!_disposed) {
-      super.notifyListeners();
-    }
-  }
-
-  void refresh() {
-    Future(() => notifyListeners());
-  }
+  void refresh() => notifyListeners();
 }
 
 class SingleTopicNTWidgetModel extends NTWidgetModel {

--- a/lib/widgets/tab_grid.dart
+++ b/lib/widgets/tab_grid.dart
@@ -661,7 +661,7 @@ class TabGridModel extends ChangeNotifier {
         widget.disposeModel(deleting: !fromLayout);
         if (!fromLayout) {
           widget.unSubscribe();
-          widget.forceDispose();
+          widget.dispose();
         }
 
         notifyListeners();
@@ -673,7 +673,7 @@ class TabGridModel extends ChangeNotifier {
       widget.disposeModel(deleting: !fromLayout);
       if (!fromLayout) {
         widget.unSubscribe();
-        widget.forceDispose();
+        widget.dispose();
       }
 
       notifyListeners();
@@ -737,9 +737,9 @@ class TabGridModel extends ChangeNotifier {
 
   void removeWidget(WidgetContainerModel widget) {
     widget.removeListener(notifyListeners);
-    widget.disposeModel(deleting: true);
     widget.unSubscribe();
-    widget.forceDispose();
+    widget.disposeModel(deleting: true);
+    widget.dispose();
     _widgetModels.remove(widget);
     notifyListeners();
   }
@@ -748,9 +748,9 @@ class TabGridModel extends ChangeNotifier {
   void clearWidgets() {
     for (WidgetContainerModel container in _widgetModels) {
       container.removeListener(notifyListeners);
-      container.disposeModel(deleting: true);
       container.unSubscribe();
-      container.forceDispose();
+      container.disposeModel(deleting: true);
+      container.dispose();
     }
     _widgetModels.clear();
     notifyListeners();
@@ -805,7 +805,7 @@ class TabGridModel extends ChangeNotifier {
       container.removeListener(notifyListeners);
       container.disposeModel(deleting: true);
       container.unSubscribe();
-      container.forceDispose();
+      container.dispose();
     }
     _widgetModels.clear();
   }

--- a/lib/widgets/tab_grid.dart
+++ b/lib/widgets/tab_grid.dart
@@ -349,7 +349,7 @@ class TabGridModel extends ChangeNotifier {
     model.previewVisible = false;
     model.validLocation = true;
 
-    model.disposeModel();
+    model.softDispose();
   }
 
   void onWidgetDragEnd(WidgetContainerModel model) {
@@ -365,7 +365,7 @@ class TabGridModel extends ChangeNotifier {
     model.previewVisible = false;
     model.validLocation = true;
 
-    model.disposeModel(deleting: false);
+    model.softDispose(deleting: false);
   }
 
   void onWidgetDragCancel(WidgetContainerModel model) {
@@ -384,7 +384,7 @@ class TabGridModel extends ChangeNotifier {
     model.resizing = false;
     model.draggingIntoLayout = false;
 
-    model.disposeModel();
+    model.softDispose();
   }
 
   void onWidgetUpdate(
@@ -658,7 +658,7 @@ class TabGridModel extends ChangeNotifier {
       if (layoutContainer.willAcceptWidget(widget)) {
         layoutContainer.addWidget(widget);
       } else {
-        widget.disposeModel(deleting: !fromLayout);
+        widget.softDispose(deleting: !fromLayout);
         if (!fromLayout) {
           widget.unSubscribe();
           widget.dispose();
@@ -670,7 +670,7 @@ class TabGridModel extends ChangeNotifier {
     } else if (!isValidMoveLocation(widget, previewLocation)) {
       _containerDraggingIn = null;
 
-      widget.disposeModel(deleting: !fromLayout);
+      widget.softDispose(deleting: !fromLayout);
       if (!fromLayout) {
         widget.unSubscribe();
         widget.dispose();
@@ -687,7 +687,7 @@ class TabGridModel extends ChangeNotifier {
 
     _containerDraggingIn = null;
 
-    widget.disposeModel();
+    widget.softDispose();
     notifyListeners();
 
     return true;
@@ -738,7 +738,7 @@ class TabGridModel extends ChangeNotifier {
   void removeWidget(WidgetContainerModel widget) {
     widget.removeListener(notifyListeners);
     widget.unSubscribe();
-    widget.disposeModel(deleting: true);
+    widget.softDispose(deleting: true);
     widget.dispose();
     _widgetModels.remove(widget);
     notifyListeners();
@@ -749,7 +749,7 @@ class TabGridModel extends ChangeNotifier {
     for (WidgetContainerModel container in _widgetModels) {
       container.removeListener(notifyListeners);
       container.unSubscribe();
-      container.disposeModel(deleting: true);
+      container.softDispose(deleting: true);
       container.dispose();
     }
     _widgetModels.clear();
@@ -803,7 +803,7 @@ class TabGridModel extends ChangeNotifier {
   void onDestroy() {
     for (WidgetContainerModel container in _widgetModels) {
       container.removeListener(notifyListeners);
-      container.disposeModel(deleting: true);
+      container.softDispose(deleting: true);
       container.unSubscribe();
       container.dispose();
     }


### PR DESCRIPTION
Initially, the app did not properly use ChangeNotifier models properly, using them as a way to rebuild stateless widgets rather than representing a state, and these would be automatically disposed while being cached, which would cause many errors to be thrown. Since then, the app's state management has been restructured, making these workarounds obsolete.