### PR TITLE
Fix robot and Elastic notifications not stacking

### DIFF
--- a/lib/pages/dashboard/dashboard_page_notifications.dart
+++ b/lib/pages/dashboard/dashboard_page_notifications.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 
 import 'package:elegant_notification/elegant_notification.dart';
+import 'package:elegant_notification/resources/stacked_options.dart';
 
 import 'package:elastic_dashboard/pages/dashboard_page.dart';
 import 'package:elastic_dashboard/services/log.dart';
@@ -115,6 +116,10 @@ mixin DashboardPageNotifications on DashboardPageViewModel {
         style: textTheme.bodyMedium!.copyWith(fontWeight: FontWeight.bold),
       ),
       description: Flexible(child: Text(message)),
+      stackedOptions: StackedOptions(
+        key: 'notification',
+        type: StackedType.above,
+      ),
     );
 
     state!.showNotification(notification);

--- a/lib/pages/dashboard_page.dart
+++ b/lib/pages/dashboard_page.dart
@@ -181,7 +181,7 @@ abstract class DashboardPageViewModel extends ChangeNotifier {
           icon: icon,
           description: Text(description),
           stackedOptions: StackedOptions(
-            key: 'robot_notification',
+            key: 'notification',
             type: StackedType.above,
           ),
         );


### PR DESCRIPTION
Fixes Elastic notifications (such as when the layout is saved) overlapping with other Elastic notifications and robot notifications.

I also noticed that the default notification width of 350 is repeated in a lot of places. While I didn't make this change in this PR, it might be good to move those repeated instances to a default argument in showNotification.