### PR TITLE
Fix split button chooser publish guard

### DIFF
--- a/lib/widgets/nt_widgets/multi_topic/split_button_chooser.dart
+++ b/lib/widgets/nt_widgets/multi_topic/split_button_chooser.dart
@@ -143,11 +143,13 @@ class SplitButtonChooserModel extends MultiTopicNTWidgetModel {
   }
 
   void publishSelectedTopic() {
-    if (_selectedTopic != null) {
+    if (_selectedTopic != null &&
+        ntConnection.isTopicPublished(_selectedTopic)) {
       return;
     }
 
-    NT4Topic? existing = ntConnection.getTopicFromName(selectedTopicName);
+    NT4Topic? existing =
+        _selectedTopic ?? ntConnection.getTopicFromName(selectedTopicName);
 
     if (existing != null) {
       existing.properties.addAll({'retained': true});
@@ -167,7 +169,8 @@ class SplitButtonChooserModel extends MultiTopicNTWidgetModel {
       return;
     }
 
-    if (_selectedTopic == null) {
+    if (_selectedTopic == null ||
+        !ntConnection.isTopicPublished(_selectedTopic)) {
       publishSelectedTopic();
     }
 


### PR DESCRIPTION
Fixes Split Button Chooser not working in cases where Combo Box does.

Previous Behavior:

https://github.com/user-attachments/assets/9dde0930-0fef-482e-9277-052ed84099cb

New Behavior: Works as intended