### PR TITLE
Add layout downloading port option

### DIFF
--- a/lib/pages/dashboard/dashboard_page_settings.dart
+++ b/lib/pages/dashboard/dashboard_page_settings.dart
@@ -37,6 +37,7 @@ mixin DashboardPageSettings on DashboardPageViewModel {
 
           updateIPAddress(data);
         },
+        onLayoutPortChanged: onLayoutPortChanged,
         onGridToggle: toggleGrid,
         onGridSizeChanged: changeGridSize,
         onCornerRadiusChanged: changeCornerRadius,
@@ -90,6 +91,70 @@ mixin DashboardPageSettings on DashboardPageViewModel {
         notifyListeners();
         break;
     }
+  }
+
+  Future<void> onLayoutPortChanged(String? data) async {
+    if (data == null) {
+      return;
+    }
+
+    int? newPort = int.tryParse(data);
+
+    if (newPort == null ||
+        (newPort.toString() == preferences.getString(PrefKeys.layoutPort))) {
+      return;
+    }
+    if (newPort < 1 || newPort > 65535) {
+      logger.warning('User entered an invalid port: $newPort');
+      await showDialog(
+        context: state!.context,
+        builder: (context) => AlertDialog(
+          title: const Text('Invalid Port'),
+          content: const Text('Please enter a valid port number (1-65535).'),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(),
+              child: const Text('Okay'),
+            ),
+          ],
+        ),
+      );
+      return;
+    }
+    bool allowedPort =
+        newPort == 80 ||
+        (newPort >= 1180 && newPort <= 1190) ||
+        (newPort >= 5800 && newPort <= 5810);
+
+    if (!allowedPort) {
+      logger.warning('User entered a potentially unsafe port: $newPort');
+      bool? proceed = await showDialog<bool>(
+        context: state!.context,
+        builder: (context) => AlertDialog(
+          title: const Text('Warning'),
+          content: const Text(
+            'The port you entered is blocked by the FMS firewall (see rule R704). \nOnly continue if you know what you\'re doing.',
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(true),
+              child: const Text('Continue'),
+            ),
+            TextButton(
+              onPressed: () => Navigator.of(context).pop(false),
+              child: const Text('Abort'),
+            ),
+          ],
+        ),
+      );
+
+      if (proceed != true) {
+        return;
+      }
+    }
+
+    await preferences.setString(PrefKeys.layoutPort, newPort.toString());
+    notifyListeners();
   }
 
   Future<void> toggleGrid(bool value) async {

--- a/lib/services/elastic_layout_downloader.dart
+++ b/lib/services/elastic_layout_downloader.dart
@@ -26,10 +26,12 @@ class ElasticLayoutDownloader {
             'Cannot download a remote layout while disconnected from the robot.',
       );
     }
+    String layoutPort =
+        preferences.getString(PrefKeys.layoutPort) ?? Defaults.layoutPort;
     String robotIP =
         preferences.getString(PrefKeys.ipAddress) ?? Defaults.ipAddress;
     String escapedName = Uri.encodeComponent('$layoutName.json');
-    Uri robotUri = Uri.parse('http://$robotIP:5800/$escapedName');
+    Uri robotUri = Uri.parse('http://$robotIP:$layoutPort/$escapedName');
     Response response;
     try {
       response = await client.get(robotUri);
@@ -61,7 +63,9 @@ class ElasticLayoutDownloader {
     }
     String robotIP =
         preferences.getString(PrefKeys.ipAddress) ?? Defaults.ipAddress;
-    Uri robotUri = Uri.parse('http://$robotIP:5800/?format=json');
+    String layoutPort =
+        preferences.getString(PrefKeys.layoutPort) ?? Defaults.layoutPort;
+    Uri robotUri = Uri.parse('http://$robotIP:$layoutPort/?format=json');
     Response response;
     try {
       response = await client.get(robotUri);

--- a/lib/services/settings.dart
+++ b/lib/services/settings.dart
@@ -50,6 +50,7 @@ class Defaults {
   static const String defaultLogLevelName = 'Automatic';
   static const Level logLevel = kDebugMode ? Level.debug : Level.info;
   static final String ipAddress = defaultIPForPlatform();
+  static final String layoutPort = '5800';
 
   static const int teamNumber = 9999;
   static const int gridSize = 128;
@@ -65,6 +66,7 @@ class Defaults {
 }
 
 class PrefKeys {
+  static String layoutPort = 'layout_port';
   static String layout = 'layout';
   static String ipAddress = 'ip_address';
   static String ipAddressMode = 'ip_address_mode';

--- a/lib/widgets/settings_dialog.dart
+++ b/lib/widgets/settings_dialog.dart
@@ -56,6 +56,7 @@ class SettingsDialog extends StatefulWidget {
   final FutureOr<void> Function(String? value)? onGridDPIChanged;
   final void Function()? onOpenAssetsFolderPressed;
   final FutureOr<void> Function(bool value)? onAutoSubmitButtonChanged;
+  final FutureOr<void> Function(String? value)? onLayoutPortChanged;
 
   const SettingsDialog({
     super.key,
@@ -78,6 +79,7 @@ class SettingsDialog extends StatefulWidget {
     this.onGridDPIChanged,
     this.onOpenAssetsFolderPressed,
     this.onAutoSubmitButtonChanged,
+    this.onLayoutPortChanged,
   });
 
   @override
@@ -159,7 +161,7 @@ class _SettingsDialogState extends State<SettingsDialog> {
                     padding: const EdgeInsets.symmetric(horizontal: 4.0),
                     child: SingleChildScrollView(
                       child: ConstrainedBox(
-                        constraints: const BoxConstraints(maxHeight: 205),
+                        constraints: const BoxConstraints(maxHeight: 260),
                         child: Column(children: [..._advancedSettings()]),
                       ),
                     ),
@@ -576,6 +578,23 @@ class _SettingsDialogState extends State<SettingsDialog> {
               icon: const Icon(Icons.folder_outlined),
               label: const Text('Open Assets Folder'),
             ),
+        ],
+      ),
+      Row(
+        children: [
+          Flexible(
+            flex: 3,
+            child: DialogTextInput(
+              initialText:
+                  widget.preferences.getString(PrefKeys.layoutPort) ??
+                  Defaults.layoutPort,
+              label: 'Layout Port',
+              onSubmit: (data) async {
+                await widget.onLayoutPortChanged?.call(data);
+                setState(() {});
+              },
+            ),
+          ),
         ],
       ),
     ];

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -125,10 +125,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -589,18 +589,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
@@ -1011,10 +1011,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   tint:
     dependency: transitive
     description:

--- a/test/pages/dashboard_page_test.dart
+++ b/test/pages/dashboard_page_test.dart
@@ -668,6 +668,7 @@ void main() {
       setUp(() async {
         SharedPreferences.setMockInitialValues({
           PrefKeys.ipAddress: '127.0.0.1',
+          PrefKeys.layoutPort: '5800',
           PrefKeys.layoutLocked: false,
         });
 
@@ -677,10 +678,11 @@ void main() {
       testWidgets('Shows list of layouts', (widgetTester) async {
         Client mockClient = createHttpClient(
           mockGetResponses: {
-            'http://127.0.0.1:5800/?format=json': Response(
-              jsonEncode(layoutFiles),
-              200,
-            ),
+            'http://${preferences.getString(PrefKeys.ipAddress)}:${preferences.getString(PrefKeys.layoutPort)}/?format=json':
+                Response(
+                  jsonEncode(layoutFiles),
+                  200,
+                ),
           },
         );
 
@@ -717,10 +719,11 @@ void main() {
         testWidgets('shows help text', (widgetTester) async {
           Client mockClient = createHttpClient(
             mockGetResponses: {
-              'http://127.0.0.1:5800/?format=json': Response(
-                jsonEncode(layoutFiles),
-                200,
-              ),
+              'http://${preferences.getString(PrefKeys.ipAddress)}:${preferences.getString(PrefKeys.layoutPort)}/?format=json':
+                  Response(
+                    jsonEncode(layoutFiles),
+                    200,
+                  ),
             },
           );
 
@@ -873,11 +876,12 @@ void main() {
           testWidgets('without merges', (widgetTester) async {
             Client mockClient = createHttpClient(
               mockGetResponses: {
-                'http://127.0.0.1:5800/?format=json': Response(
-                  jsonEncode(layoutFiles),
-                  200,
-                ),
-                'http://127.0.0.1:5800/${Uri.encodeComponent('elastic-layout 1.json')}':
+                'http://${preferences.getString(PrefKeys.ipAddress)}:${preferences.getString(PrefKeys.layoutPort)}/?format=json':
+                    Response(
+                      jsonEncode(layoutFiles),
+                      200,
+                    ),
+                'http://${preferences.getString(PrefKeys.ipAddress)}:${preferences.getString(PrefKeys.layoutPort)}/${Uri.encodeComponent('elastic-layout 1.json')}':
                     Response(jsonEncode(layoutOne), 200),
               },
             );
@@ -1047,11 +1051,12 @@ void main() {
       testWidgets('reload mode', (widgetTester) async {
         Client mockClient = createHttpClient(
           mockGetResponses: {
-            'http://127.0.0.1:5800/?format=json': Response(
-              jsonEncode(layoutFiles),
-              200,
-            ),
-            'http://127.0.0.1:5800/${Uri.encodeComponent('elastic-layout 1.json')}':
+            'http://${preferences.getString(PrefKeys.ipAddress)}:${preferences.getString(PrefKeys.layoutPort)}/?format=json':
+                Response(
+                  jsonEncode(layoutFiles),
+                  200,
+                ),
+            'http://${preferences.getString(PrefKeys.ipAddress)}:${preferences.getString(PrefKeys.layoutPort)}/${Uri.encodeComponent('elastic-layout 1.json')}':
                 Response(jsonEncode(layoutOne), 200),
           },
         );
@@ -1154,7 +1159,8 @@ void main() {
         testWidgets('layout fetching is not a json', (widgetTester) async {
           Client mockClient = createHttpClient(
             mockGetResponses: {
-              'http://127.0.0.1:5800/?format=json': Response('[1, 2, 3]', 200),
+              'http://${preferences.getString(PrefKeys.ipAddress)}:${preferences.getString(PrefKeys.layoutPort)}/?format=json':
+                  Response('[1, 2, 3]', 200),
             },
           );
 
@@ -1190,7 +1196,8 @@ void main() {
         testWidgets('layout json does not list files', (widgetTester) async {
           Client mockClient = createHttpClient(
             mockGetResponses: {
-              'http://127.0.0.1:5800/?format=json': Response('{}', 200),
+              'http://${preferences.getString(PrefKeys.ipAddress)}:${preferences.getString(PrefKeys.layoutPort)}/?format=json':
+                  Response('{}', 200),
             },
           );
 
@@ -1226,10 +1233,11 @@ void main() {
         testWidgets('layout json has empty files list', (widgetTester) async {
           Client mockClient = createHttpClient(
             mockGetResponses: {
-              'http://127.0.0.1:5800/?format=json': Response(
-                jsonEncode({'files': []}),
-                200,
-              ),
+              'http://${preferences.getString(PrefKeys.ipAddress)}:${preferences.getString(PrefKeys.layoutPort)}/?format=json':
+                  Response(
+                    jsonEncode({'files': []}),
+                    200,
+                  ),
             },
           );
 
@@ -1265,11 +1273,12 @@ void main() {
         testWidgets('selected file was not found', (widgetTester) async {
           Client mockClient = createHttpClient(
             mockGetResponses: {
-              'http://127.0.0.1:5800/?format=json': Response(
-                jsonEncode(layoutFiles),
-                200,
-              ),
-              'http://127.0.0.1:5800/${Uri.encodeComponent('elastic-layout 1.json')}':
+              'http://${preferences.getString(PrefKeys.ipAddress)}:${preferences.getString(PrefKeys.layoutPort)}/?format=json':
+                  Response(
+                    jsonEncode(layoutFiles),
+                    200,
+                  ),
+              'http://${preferences.getString(PrefKeys.ipAddress)}:${preferences.getString(PrefKeys.layoutPort)}/${Uri.encodeComponent('elastic-layout 1.json')}':
                   Response('', 404),
             },
           );


### PR DESCRIPTION
This PR aims to fix #246, giving users the option to use a custom port for the "Download from Robot" web server. I didn't actually add a unit test for that functionality specifically, but I integrated the preferences key into existing unit tests, and tested that it worked manually.